### PR TITLE
fix(docs): rst_sample SQL example samples an in-extent NYC point (#51)

### DIFF
--- a/docs/tests/python/api/rasterx_functions_sql.py
+++ b/docs/tests/python/api/rasterx_functions_sql.py
@@ -1990,17 +1990,20 @@ rst_fillnodata_sql_example_output = """
 def rst_sample_sql_example():
     """Sample raster pixel values at a POINT geometry (one Double per band)."""
     return """
--- Sample at a known lon/lat (point must be in the raster's CRS).
-SELECT gbx_rst_sample(tile, 'POINT(-0.13 51.5)') AS values FROM rasters;
+-- Sample at a known lon/lat. Tagging the point with an SRID (EWKT
+-- `SRID=4326;...`) makes gbx_rst_sample reproject it to each raster's CRS, so
+-- this lon/lat over NYC lands correctly on the (UTM) Sentinel-2 raster.
+SELECT gbx_rst_sample(tile, 'SRID=4326;POINT(-73.97 40.75)') AS values FROM rasters;
 """
 
 
 rst_sample_sql_example_output = """
-+-------------------+
-|values             |
-+-------------------+
-|[12.5, 88.0, 240.0]|
-+-------------------+
++--------+
+|values  |
++--------+
+|[1894.0]|
+|NULL    |
++--------+
 """
 
 

--- a/docs/tests/python/api/test_rasterx_functions_sql.py
+++ b/docs/tests/python/api/test_rasterx_functions_sql.py
@@ -549,7 +549,7 @@ def test_rst_color_relief_sql_example(spark, rasters_view, tmp_path):
     ("rst_fillnodata_sql_example",
      "SELECT gbx_rst_fillnodata(tile, 100.0, 0) AS filled FROM rasters"),
     ("rst_sample_sql_example",
-     "SELECT gbx_rst_sample(tile, 'POINT(-0.13 51.5)') AS vals FROM rasters"),
+     "SELECT gbx_rst_sample(tile, 'SRID=4326;POINT(-73.97 40.75)') AS vals FROM rasters"),
     ("rst_setsrid_sql_example",
      "SELECT gbx_rst_setsrid(tile, 4326) AS tagged FROM rasters"),
     ("rst_histogram_sql_example",


### PR DESCRIPTION
## Summary

Fixes the `rst_sample` RasterX SQL doc example (issue #51): it sampled a bare-WKT `POINT(-0.13 51.5)` — London — against the NYC `rasters` view. A bare WKT has no SRID, so `gbx_rst_sample` reads the coords in the raster's own CRS: a nonsense location on the UTM Sentinel-2 raster, and London on the WGS84 SRTM raster → correctly returns null, so `test_pixel_ops_sql_example` failed `assert None is not None`. The documented output `[12.5, 88.0, 240.0]` was never producible.

## Fix

- Example (`docs/tests/python/api/rasterx_functions_sql.py`) and the test's fallback SQL (`docs/tests/python/api/test_rasterx_functions_sql.py`) now sample an EWKT point `SRID=4326;POINT(-73.97 40.75)` (Lower Manhattan). The SRID makes `gbx_rst_sample` reproject the point to each raster's CRS, so it lands on the Sentinel-2 red band → `[1894.0]`.
- Updated `rst_sample_sql_example_output` to the real result and fixed the misleading "point must be in the raster's CRS" comment (the SRID now drives reprojection).

## Verification

RasterX SQL doc-test run in the geobrix-dev container: `test_pixel_ops_sql_example` — **7 passed** (incl. the `rst_sample` parametrization). Full doc/CI suite runs on this PR.

Fixes #51

This pull request and its description were written by Isaac.
