### PR TITLE
fix(docs): stop -W error promoting the vizx static-fallback UserWarning (#52)

### DIFF
--- a/docs/tests/python/api/test_vizx_viewers.py
+++ b/docs/tests/python/api/test_vizx_viewers.py
@@ -3,6 +3,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 import vizx_viewers as ex  # noqa: E402
@@ -12,6 +14,12 @@ def test_pmtiles_info_example():
     ex.pmtiles_info_example()
 
 
+# The static-render demo (max_embed_mb=0) intentionally emits benign UserWarnings
+# — the "falling back to static render" fallback notice and a contextily
+# "inferred zoom level … not valid for the current tile provider" notice — which
+# pytest.ini's `-W error::UserWarning` would otherwise promote to failures. Scope
+# an ignore to this one demo test; the example still asserts a figure was produced.
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_plot_pmtiles_static_example():
     ex.plot_pmtiles_static_example()
 


### PR DESCRIPTION
## Summary

Fixes issue #52: `test_plot_pmtiles_static_example` failed deterministically wherever the `api/` doc-tests run. The example calls `plot_pmtiles(archive, max_embed_mb=0, …)`, which deliberately demonstrates the **static-render fallback** and emits a `UserWarning` by design; `docs/tests/pytest.ini` sets `-W error::UserWarning`, promoting that expected warning to an error.

## Fix

Scope `@pytest.mark.filterwarnings("ignore::UserWarning")` to just this demo test (and `import pytest`). While fixing it, the run surfaced a **second** benign warning on the fallback path — contextily's `"inferred zoom level … not valid for the current tile provider"` — which a message-matched `pytest.warns` would have missed; the `filterwarnings` ignore covers both. The example still asserts a matplotlib figure was produced.

## Verification

vizx doc-test in the geobrix-dev container: `test_plot_pmtiles_static_example` — **1 passed** (1.47s). Full doc/CI suite runs on this PR.

Fixes #52

This pull request and its description were written by Isaac.
