### PR TITLE
fix: value reducers return NULL for all-nodata raster chips (both tiers)

### DIFF
--- a/python/geobrix/src/databricks/labs/gbx/pyrx/core/accessors.py
+++ b/python/geobrix/src/databricks/labs/gbx/pyrx/core/accessors.py
@@ -117,39 +117,39 @@ def _valid_values(ds, band_index: int) -> np.ndarray:
     return arr[mask != 0].ravel()
 
 
-def avg(ds) -> List[float]:
-    """Per-band mean of valid pixels; NaN for empty/all-invalid bands."""
+def avg(ds) -> List[Optional[float]]:
+    """Per-band mean of valid pixels; None for empty/all-invalid bands."""
     out = []
     for bi in range(1, ds.count + 1):
         vals = _valid_values(ds, bi)
-        out.append(float(np.mean(vals)) if vals.size else float("nan"))
+        out.append(float(np.mean(vals)) if vals.size else None)
     return out
 
 
-def minimum(ds) -> List[float]:
-    """Per-band min of valid pixels; NaN for empty/all-invalid bands."""
+def minimum(ds) -> List[Optional[float]]:
+    """Per-band min of valid pixels; None for empty/all-invalid bands."""
     out = []
     for bi in range(1, ds.count + 1):
         vals = _valid_values(ds, bi)
-        out.append(float(np.min(vals)) if vals.size else float("nan"))
+        out.append(float(np.min(vals)) if vals.size else None)
     return out
 
 
-def maximum(ds) -> List[float]:
-    """Per-band max of valid pixels; NaN for empty/all-invalid bands."""
+def maximum(ds) -> List[Optional[float]]:
+    """Per-band max of valid pixels; None for empty/all-invalid bands."""
     out = []
     for bi in range(1, ds.count + 1):
         vals = _valid_values(ds, bi)
-        out.append(float(np.max(vals)) if vals.size else float("nan"))
+        out.append(float(np.max(vals)) if vals.size else None)
     return out
 
 
-def median(ds) -> List[float]:
-    """Per-band median of valid pixels; NaN for empty/all-invalid bands."""
+def median(ds) -> List[Optional[float]]:
+    """Per-band median of valid pixels; None for empty/all-invalid bands."""
     out = []
     for bi in range(1, ds.count + 1):
         vals = _valid_values(ds, bi)
-        out.append(float(np.median(vals)) if vals.size else float("nan"))
+        out.append(float(np.median(vals)) if vals.size else None)
     return out
 
 

--- a/python/geobrix/test/pyrx/test_core_accessors_stats.py
+++ b/python/geobrix/test/pyrx/test_core_accessors_stats.py
@@ -67,15 +67,23 @@ def test_stats_multiband():
         assert accessors.pixelcount(ds) == [12, 12]
 
 
-def test_stats_all_invalid_band_is_nan_zero():
+def test_stats_all_invalid_band_is_none_zero():
+    # All-nodata band: reducers must return None (not NaN), pixelcount 0.
     data = np.full((2, 2), -9999.0, dtype="float32")
     raster = _custom_raster(data)
     with _serde.open_tile(raster) as ds:
-        assert math.isnan(accessors.avg(ds)[0])
-        assert math.isnan(accessors.minimum(ds)[0])
-        assert math.isnan(accessors.maximum(ds)[0])
-        assert math.isnan(accessors.median(ds)[0])
+        assert accessors.avg(ds) == [None]
+        assert accessors.minimum(ds) == [None]
+        assert accessors.maximum(ds) == [None]
+        assert accessors.median(ds) == [None]
         assert accessors.pixelcount(ds) == [0]
+        # explicit: the old NaN footgun is gone
+        assert accessors.maximum(ds)[0] is None
+        assert not any(
+            isinstance(v[0], float) and math.isnan(v[0])
+            for v in (accessors.avg(ds), accessors.minimum(ds),
+                      accessors.maximum(ds), accessors.median(ds))
+        )
 
 
 # --- geotransform-derived accessors -----------------------------------------

--- a/python/geobrix/test/pyrx/test_covering_nodata_null.py
+++ b/python/geobrix/test/pyrx/test_covering_nodata_null.py
@@ -1,0 +1,38 @@
+"""Covering over a raster with an interior nodata hole: every all-nodata cell
+must reduce to None (not NaN), and cells with data keep their value."""
+import math
+import numpy as np
+from rasterio.io import MemoryFile
+from rasterio.transform import from_origin
+from databricks.labs.gbx.pyrx import _serde
+from databricks.labs.gbx.pyrx.core import tessellate, accessors
+
+
+def _raster_with_hole(nodata=-9999.0):
+    data = np.full((9, 9), 42.0, dtype="float32")
+    data[3:6, 3:6] = nodata  # interior hole
+    with MemoryFile() as mf:
+        with mf.open(driver="GTiff", width=9, height=9, count=1, dtype="float32",
+                     crs="EPSG:4326", transform=from_origin(10.0, 50.0, 0.0022, 0.0022),
+                     nodata=nodata) as dst:
+            dst.write(data, 1)
+        return mf.read()
+
+
+def test_covering_empty_cells_reduce_to_none():
+    tif = _raster_with_hole()
+    empties = 0
+    with _serde.open_tile(tif) as ds:
+        chips = list(tessellate.iter_tessellate_h3(ds, 10, mode="covering"))
+    assert len(chips) > 0
+    for _cellid, rb in chips:
+        with _serde.open_tile(rb) as cds:
+            mx = accessors.maximum(cds)[0]
+            pc = accessors.pixelcount(cds)[0]
+        if pc == 0:
+            empties += 1
+            assert mx is None                      # NULL, not NaN
+            assert not (isinstance(mx, float) and math.isnan(mx))
+        else:
+            assert mx is not None and mx == 42.0   # real cells unaffected
+    assert empties > 0   # the hole DOES create empty cells (bug would be masked otherwise)

--- a/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Avg.scala
+++ b/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Avg.scala
@@ -2,11 +2,12 @@ package com.databricks.labs.gbx.rasterx.expressions.accessors
 
 import com.databricks.labs.gbx.expressions._
 import com.databricks.labs.gbx.rasterx.gdal.RasterDriver
+import com.databricks.labs.gbx.rasterx.operations.BandAccessors
 import com.databricks.labs.gbx.rasterx.util.{RST_ErrorHandler, RST_ExpressionUtil, RasterSerializationUtil}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.gdal.gdal.Dataset
@@ -43,7 +44,7 @@ object RST_Avg extends WithExpressionInfo {
                 val ds = RasterSerializationUtil.rowToDS(row, dt)
                 val res = execute(ds)
                 RasterDriver.releaseDataset(ds)
-                ArrayData.toArrayData(res)
+                new GenericArrayData(res.asInstanceOf[Array[Any]])
             },
             row,
             dt,
@@ -51,14 +52,15 @@ object RST_Avg extends WithExpressionInfo {
           )
         ).map(_.asInstanceOf[ArrayData]).orNull
 
-    def execute(ds: Dataset): Array[Double] = {
+    def execute(ds: Dataset): Array[java.lang.Double] = {
         (1 to ds.GetRasterCount()).map { bandIndex =>
             val band = ds.GetRasterBand(bandIndex)
-            if (band == null) Double.NaN
+            if (band == null) null
+            else if (BandAccessors.isEmpty(band)) { band.delete(); null }
             else {
                 val stats = band.AsMDArray().GetStatistics()
-                if (stats == null) Double.NaN
-                else stats.getMean
+                band.delete()
+                if (stats == null) null else java.lang.Double.valueOf(stats.getMean)
             }
         }.toArray
     }

--- a/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Max.scala
+++ b/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Max.scala
@@ -7,7 +7,7 @@ import com.databricks.labs.gbx.rasterx.util.{RST_ErrorHandler, RST_ExpressionUti
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.gdal.gdal.Dataset
@@ -43,7 +43,7 @@ object RST_Max extends WithExpressionInfo {
                 val ds = RasterSerializationUtil.rowToDS(row, rdt)
                 val res = execute(ds)
                 RasterDriver.releaseDataset(ds)
-                ArrayData.toArrayData(res)
+                new GenericArrayData(res.asInstanceOf[Array[Any]])
             },
             row,
             rdt,
@@ -51,14 +51,15 @@ object RST_Max extends WithExpressionInfo {
           )
         ).map(_.asInstanceOf[ArrayData]).orNull
 
-    def execute(ds: Dataset): Array[Double] = {
+    def execute(ds: Dataset): Array[java.lang.Double] = {
         (1 to ds.GetRasterCount()).map { bandIndex =>
             val band = ds.GetRasterBand(bandIndex)
-            if (band == null) Double.NaN
+            if (band == null) null
+            else if (BandAccessors.isEmpty(band)) { band.delete(); null }
             else {
                 val (_, max) = BandAccessors.getMinMax(band)
                 band.delete()
-                max
+                java.lang.Double.valueOf(max)
             }
         }.toArray
     }

--- a/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Median.scala
+++ b/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Median.scala
@@ -3,11 +3,12 @@ package com.databricks.labs.gbx.rasterx.expressions.accessors
 import com.databricks.labs.gbx.expressions.{ExpressionConfig, ExpressionConfigExpr, InvokedExpression, WithExpressionInfo}
 import com.databricks.labs.gbx.rasterx.gdal.{GDAL, RasterDriver}
 import com.databricks.labs.gbx.rasterx.operator.GDALWarp
+import com.databricks.labs.gbx.rasterx.operations.BandAccessors
 import com.databricks.labs.gbx.rasterx.util.{RST_ErrorHandler, RST_ExpressionUtil, RasterSerializationUtil}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.gdal.gdal.{Dataset, gdal}
@@ -43,7 +44,7 @@ object RST_Median extends WithExpressionInfo {
                 val ds = RasterSerializationUtil.rowToDS(row, rdt)
                 val res = execute(ds, Map.empty)
                 RasterDriver.releaseDataset(ds)
-                ArrayData.toArrayData(res)
+                new GenericArrayData(res.asInstanceOf[Array[Any]])
             },
             row,
             rdt,
@@ -51,17 +52,29 @@ object RST_Median extends WithExpressionInfo {
           )
         ).map(_.asInstanceOf[ArrayData]).orNull
 
-    def execute(ds: Dataset, options: Map[String, String]): Array[Double] = {
+    def execute(ds: Dataset, options: Map[String, String]): Array[java.lang.Double] = {
         val outShortName = ds.GetDriver().getShortName
         val uuid = java.util.UUID.randomUUID().toString.replace("-", "")
         val extension = GDAL.getExtension(outShortName)
         val resultPath = s"/vsimem/rst_median_$uuid.$extension"
         val cmd = s"gdalwarp -r med -ts 1 1"
         val (resDs, _) = GDALWarp.executeWarp(resultPath, Array(ds), options, cmd)
-        val maxValues = (1 to resDs.GetRasterCount()).map(i => resDs.GetRasterBand(i).AsMDArray().GetStatistics().getMax)
+        val bandCount = ds.GetRasterCount()
+        val maxValues = (1 to bandCount).map { i =>
+            val srcBand = ds.GetRasterBand(i)
+            if (srcBand == null) null
+            else if (BandAccessors.isEmpty(srcBand)) { srcBand.delete(); null }
+            else {
+                srcBand.delete()
+                val resBand = resDs.GetRasterBand(i)
+                val stats = resBand.AsMDArray().GetStatistics()
+                resBand.delete()
+                if (stats == null) null else java.lang.Double.valueOf(stats.getMax)
+            }
+        }.toArray
         resDs.delete()
         gdal.Unlink(resultPath)
-        maxValues.toArray
+        maxValues
     }
 
     override def name: String = "gbx_rst_median"

--- a/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Min.scala
+++ b/src/main/scala/com/databricks/labs/gbx/rasterx/expressions/accessors/RST_Min.scala
@@ -7,7 +7,7 @@ import com.databricks.labs.gbx.rasterx.util.{RST_ErrorHandler, RST_ExpressionUti
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.gdal.gdal.Dataset
@@ -43,7 +43,7 @@ object RST_Min extends WithExpressionInfo {
                 val ds = RasterSerializationUtil.rowToDS(row, rdt)
                 val res = execute(ds)
                 RasterDriver.releaseDataset(ds)
-                ArrayData.toArrayData(res)
+                new GenericArrayData(res.asInstanceOf[Array[Any]])
             },
             row,
             rdt,
@@ -51,14 +51,15 @@ object RST_Min extends WithExpressionInfo {
           )
         ).map(_.asInstanceOf[ArrayData]).orNull
 
-    def execute(ds: Dataset): Array[Double] = {
+    def execute(ds: Dataset): Array[java.lang.Double] = {
         (1 to ds.GetRasterCount()).map { bandIndex =>
             val band = ds.GetRasterBand(bandIndex)
-            if (band == null) Double.NaN
+            if (band == null) null
+            else if (BandAccessors.isEmpty(band)) { band.delete(); null }
             else {
                 val (min, _) = BandAccessors.getMinMax(band)
                 band.delete()
-                min
+                java.lang.Double.valueOf(min)
             }
         }.toArray
     }

--- a/src/test/scala/com/databricks/labs/gbx/bench/BenchFingerprint.scala
+++ b/src/test/scala/com/databricks/labs/gbx/bench/BenchFingerprint.scala
@@ -39,6 +39,17 @@ object BenchFingerprint {
     mapper.writeValueAsString(n)
   }
 
+  // Boxed variant for reducers that return NULL for all-nodata bands (RST_Max/Min/Avg/Median).
+  // A null element is emitted as a JSON null — matching the python bench (None -> null), NOT NaN —
+  // so cross-tier fingerprints agree on all-nodata inputs.
+  def ofArray(values: Array[java.lang.Double]): String = {
+    val n = mapper.createObjectNode()
+    n.put("kind", "scalar_list")
+    val arr: ArrayNode = n.putArray("values")
+    values.foreach(v => if (v == null) arr.addNull() else arr.add(v.doubleValue()))
+    mapper.writeValueAsString(n)
+  }
+
   /** Fingerprint a COLLECTION of output tiles (bucket C, group C4 tiling fns).
     *
     * Mirrors python bench/fingerprint.py `fingerprint_collection`: records the tile

--- a/src/test/scala/com/databricks/labs/gbx/bench/BenchFingerprintNullTest.scala
+++ b/src/test/scala/com/databricks/labs/gbx/bench/BenchFingerprintNullTest.scala
@@ -1,0 +1,46 @@
+package com.databricks.labs.gbx.bench
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * GDAL-free tests for BenchFingerprint.ofArray(Array[java.lang.Double]) — the boxed overload used by
+ * the value reducers (RST_Max/Min/Avg/Median) now that they return NULL for all-nodata bands.
+ *
+ * Separate suite (no GDAL beforeAll) so it runs without the gdalalljni native lib: ofArray touches
+ * only Jackson + java.lang.Double, and the BenchFingerprint object initializes to just an ObjectMapper.
+ *
+ * The contract under test: a null element must serialize as JSON `null` (matching python bench
+ * fingerprint.py `_py(None) -> null`), NOT as NaN — so cross-tier fingerprints agree on all-nodata input.
+ */
+class BenchFingerprintNullTest extends AnyFunSuite {
+  private val mapper = new ObjectMapper()
+
+  test("boxed ofArray emits JSON null for a null element (matches python null, not NaN)") {
+    val fp = BenchFingerprint.ofArray(Array[java.lang.Double](java.lang.Double.valueOf(42.0), null))
+    val node = mapper.readTree(fp)
+    assert(node.get("kind").asText() == "scalar_list")
+    val values = node.get("values")
+    assert(values.get(0).asDouble() == 42.0)
+    // the null element must be a JSON null token — NOT a NaN number
+    assert(values.get(1).isNull, s"expected JSON null for empty-band element, got: ${values.get(1)}")
+    assert(!values.get(1).isNumber, "null element must not serialize as a (NaN) number")
+    // and the serialized form contains `null`, never `NaN`
+    assert(fp.contains("null"), s"serialized fingerprint should contain a JSON null: $fp")
+    assert(!fp.contains("NaN"), s"serialized fingerprint must not contain NaN: $fp")
+  }
+
+  test("boxed ofArray with all real values matches the primitive overload") {
+    val boxed = BenchFingerprint.ofArray(Array[java.lang.Double](
+      java.lang.Double.valueOf(1.0), java.lang.Double.valueOf(2.0)))
+    val prim = BenchFingerprint.ofArray(Array(1.0, 2.0))
+    assert(boxed == prim, s"boxed and primitive overloads must agree on non-null input: $boxed vs $prim")
+  }
+
+  test("boxed ofArray with all-null (fully empty band set) emits all JSON nulls") {
+    val fp = BenchFingerprint.ofArray(Array[java.lang.Double](null, null))
+    val values = mapper.readTree(fp).get("values")
+    assert(values.get(0).isNull && values.get(1).isNull)
+    assert(!fp.contains("NaN"))
+  }
+}

--- a/src/test/scala/com/databricks/labs/gbx/rasterx/expressions/RST_AccessorsExecuteTest.scala
+++ b/src/test/scala/com/databricks/labs/gbx/rasterx/expressions/RST_AccessorsExecuteTest.scala
@@ -3,6 +3,7 @@ package com.databricks.labs.gbx.rasterx.expressions
 import com.databricks.labs.gbx.rasterx.expressions.accessors.{RST_Avg, RST_BandMetaData, RST_BoundingBox, RST_Format, RST_GeoReference, RST_GetNoData, RST_GetSubdataset, RST_Height, RST_Max, RST_Median, RST_MemSize, RST_MetaData, RST_Min, RST_NumBands, RST_PixelCount, RST_PixelHeight, RST_PixelWidth, RST_Rotation, RST_SRID, RST_ScaleX, RST_ScaleY, RST_SkewX, RST_SkewY, RST_Subdatasets, RST_Summary, RST_Type, RST_UpperLeftX, RST_UpperLeftY, RST_Width}
 import com.databricks.labs.gbx.rasterx.gdal.GDALManager
 import org.gdal.gdal.{Dataset, gdal}
+import org.gdal.gdalconst.gdalconstConstants
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
@@ -242,5 +243,70 @@ class RST_AccessorsExecuteTest extends AnyFunSuite with BeforeAndAfterAll {
         width shouldBe ds.GetRasterXSize()
     }
 
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /** Creates a 2×2 Float32 in-memory GTiff where all pixels equal the nodata value (-9999). */
+    private def allNodataDataset(): Dataset = {
+        val path = "/vsimem/all_nodata_test.tif"
+        val driver = gdal.GetDriverByName("GTiff")
+        val outDs = driver.Create(path, 2, 2, 1, gdalconstConstants.GDT_Float32)
+        val band = outDs.GetRasterBand(1)
+        band.SetNoDataValue(-9999.0)
+        val pixels = Array(-9999.0f, -9999.0f, -9999.0f, -9999.0f)
+        band.WriteRaster(0, 0, 2, 2, pixels)
+        outDs.FlushCache()
+        band.delete()
+        // Re-open so the mask band is initialised properly
+        outDs.delete()
+        gdal.Open(path)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Empty-band (all-nodata) contract
+    // ---------------------------------------------------------------------------
+
+    test("RST_Max returns null element for an all-nodata band") {
+        val nodataDs = allNodataDataset()
+        try {
+            val max = RST_Max.execute(nodataDs)
+            max(0) shouldBe null
+        } finally {
+            nodataDs.delete()
+            gdal.Unlink("/vsimem/all_nodata_test.tif")
+        }
+    }
+
+    test("RST_Min returns null element for an all-nodata band") {
+        val nodataDs = allNodataDataset()
+        try {
+            val min = RST_Min.execute(nodataDs)
+            min(0) shouldBe null
+        } finally {
+            nodataDs.delete()
+            gdal.Unlink("/vsimem/all_nodata_test.tif")
+        }
+    }
+
+    test("RST_Avg returns null element for an all-nodata band") {
+        val nodataDs = allNodataDataset()
+        try {
+            RST_Avg.execute(nodataDs)(0) shouldBe null
+        } finally {
+            nodataDs.delete()
+            gdal.Unlink("/vsimem/all_nodata_test.tif")
+        }
+    }
+
+    test("RST_Median returns null element for an all-nodata band") {
+        val nodataDs = allNodataDataset()
+        try {
+            RST_Median.execute(nodataDs, Map.empty)(0) shouldBe null
+        } finally {
+            nodataDs.delete()
+            gdal.Unlink("/vsimem/all_nodata_test.tif")
+        }
+    }
 
 }


### PR DESCRIPTION
Fixes #59.

## Problem

When a raster chip's band has **zero valid pixels** — e.g. an H3 covering-tessellation cell that overlaps only nodata — the value reducers return a misleading result instead of a clear "no data" signal, and the two tiers disagree:

- **Light tier** (`pyrx`): `gbx_rst_max/min/avg/median` return `NaN`.
- **Heavy tier** (`rasterx`): the same functions return `0.0`.

Both are problematic downstream:

1. **`NaN` (light)** silently passes `WHERE measure IS NOT NULL`, and **poisons `MAX()` in a `GROUP BY`** — because NaN sorts greater than everything, a cell that has real data but also touches an all-nodata chip across a tile seam can have its true value overwritten with NaN during reconciliation.
2. **`0.0` (heavy)** is indistinguishable from a genuine zero measurement.

## Fix

Both tiers now return **SQL `NULL`** for a band with zero valid pixels. NULL is catchable (`WHERE measure IS NULL`) and aggregation-safe (ignored by `MAX`/`AVG`).

- **Light** (`pyrx/core/accessors.py`): `avg/minimum/maximum/median` return `None` on an empty band. `pixelcount` still returns `0`; `tessellate` still emits the cell.
- **Heavy** (`rasterx/expressions/accessors/`): `RST_Max/Min/Avg/Median` return a `null` element for a null or all-nodata band (via the existing `BandAccessors.isEmpty`). `execute` returns `Array[java.lang.Double]` (a primitive array can't hold null) and `eval` wraps with `GenericArrayData` to preserve null elements. `RST_Median` also disposes source/warped bands on every path.
- `BenchFingerprint` gains a boxed `ofArray(Array[java.lang.Double])` overload that emits JSON `null` (matching the Python bench), so cross-tier fingerprints agree on all-nodata input.

`RST_H3_RasterToGrid*` (centroid mode) was audited and is structurally unaffected — it only visits valid pixels, so it never produces an all-nodata cell.

## Testing

- **Light**: unit tests for the empty-band case (returns `None`, not NaN) and an end-to-end covering test over a raster with an interior nodata hole — every empty cell reduces to `None`, valid cells unchanged.
- **Heavy**: ScalaTest cases asserting `null` for all-nodata bands across all four reducers; `BenchFingerprintNullTest` (GDAL-free) verifies the JSON-null bench parity.
- **End-to-end on a live workspace, both tiers**, over a raster with an interior nodata hole (every all-nodata covering cell reduces to `measure IS NULL` with `0` NaN; valid cells unchanged):
  - **Light tier** via a **Databricks serverless** notebook, exercising the real `gbx_rst_max` UDF path (Spark 4.0).
  - **Heavy tier** on a **Databricks Runtime 18.2 cluster** (Spark 4.1, Scala 2.13) with the GDAL-enabled JAR.
