### PR TITLE
fix(docs): pin serve-handler to 6.1.6 to unblock docs deploy

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3560,6 +3560,39 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/core/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://npm-proxy.cloud.databricks.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "license": "MIT"
+    },
+    "node_modules/@docusaurus/core/node_modules/serve-handler": {
+      "version": "6.1.6",
+      "resolved": "https://npm-proxy.cloud.databricks.com/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.2",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
     "node_modules/@docusaurus/cssnano-preset": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
@@ -12719,6 +12752,7 @@
       "version": "3.1.5",
       "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -16193,27 +16227,6 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
-    },
-    "node_modules/serve-handler": {
-      "version": "6.1.7",
-      "resolved": "https://npm-proxy.cloud.databricks.com/serve-handler/-/serve-handler-6.1.7.tgz",
-      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.0.0",
-        "content-disposition": "0.5.2",
-        "mime-types": "2.1.18",
-        "minimatch": "3.1.5",
-        "path-is-inside": "1.0.2",
-        "path-to-regexp": "3.3.0",
-        "range-parser": "1.2.0"
-      }
-    },
-    "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
-      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
-      "license": "MIT"
     },
     "node_modules/serve-index": {
       "version": "1.9.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,6 +32,9 @@
     "playwright": "^1.58.0",
     "raw-loader": "^4.0.2"
   },
+  "overrides": {
+    "serve-handler": "6.1.6"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## Docs-deploy hotfix (`beta/0.5.0` → `main`)

Follows the merged 0.5.0 release (#72). One commit: `a90aae5f`.

### Problem
The **Deploy documentation** workflow (main-only) failed twice at **Install dependencies** — `npm ci` hung ~8 min then `ECONNRESET` fetching `serve-handler-6.1.7.tgz` from the Databricks npm proxy (TLS socket disconnect). Deterministic on that one tarball: the 0.5.0 `@docusaurus/core` bump (3.9.2) floated the transitive `serve-handler` dep up to 6.1.7, which the proxy hasn't mirrored. 6.1.6 is cached and is the version that deployed cleanly on 0.4.3.

### Fix
- Add an npm `override` in `docs/package.json` pinning `serve-handler` to `6.1.6` (satisfies core's `^6.1.6`) and regenerate `docs/package-lock.json`.
- `serve-handler` is only used by `docusaurus serve` (local preview), never by the `docusaurus build` the deploy runs — pinning the patch back is zero-risk for docs output.
- The regen also repoints `path-to-regexp` off `registry.npmjs.org` onto the proxy.

The docs deploy revalidates on merge to `main`. **Merge with a merge commit, not a squash** — `beta/0.5.0` is the long-lived release line.

This pull request and its description were written by Isaac.