### PR TITLE
fix(docs): pin floated transitive deps to 0.4.3-good versions

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3578,6 +3578,22 @@
       "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
       "license": "MIT"
     },
+    "node_modules/@docusaurus/core/node_modules/react-loadable-ssr-addon-v5-slorber": {
+      "version": "1.0.1",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
+      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "react-loadable": "*",
+        "webpack": ">=4.41.1 || 5.x"
+      }
+    },
     "node_modules/@docusaurus/core/node_modules/serve-handler": {
       "version": "6.1.6",
       "resolved": "https://npm-proxy.cloud.databricks.com/serve-handler/-/serve-handler-6.1.6.tgz",
@@ -12748,19 +12764,6 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -15359,22 +15362,6 @@
         "react": "*"
       }
     },
-    "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.3",
-      "resolved": "https://npm-proxy.cloud.databricks.com/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
-      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "react-loadable": "*",
-        "webpack": ">=4.41.1 || 5.x"
-      }
-    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -15530,6 +15517,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/recursive-readdir/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/regenerate": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,9 @@
     "raw-loader": "^4.0.2"
   },
   "overrides": {
-    "serve-handler": "6.1.6"
+    "serve-handler": "6.1.6",
+    "react-loadable-ssr-addon-v5-slorber": "1.0.1",
+    "minimatch": "3.1.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Docs-deploy hotfix #2 (`beta/0.5.0` → `main`)

Follow-up to #73. One commit: `9b9e3e93`.

### Problem
After the serve-handler pin, the **Deploy documentation** build failed again at **Install dependencies** — `npm ci` hung ~8 min then `ECONNRESET` fetching `react-loadable-ssr-addon-v5-slorber-1.0.3.tgz` from the Databricks npm proxy. Same root cause, different package.

### Diagnosis
`@docusaurus/core` is **3.9.2 in both** the last successful deploy (0.4.3) and 0.5.0 — no docusaurus bump. But the branch's lockfile regen floated two transitive deps up to newer, unmirrored patches:
- `react-loadable-ssr-addon-v5-slorber` 1.0.1 → 1.0.3
- `minimatch` gained 3.1.5 alongside 3.1.2

### Fix
Pin both back to their 0.4.3 versions via npm `overrides` (both satisfy core's ranges) and regenerate the lockfile. The docs lockfile now matches the known-good 0.4.3 deploy **exactly except** for `plugin-client-redirects-3.9.2` — a new dep whose @docusaurus 3.9.2 siblings the proxy already serves, so it should be cached. Build output is unaffected (build-graph/runtime helpers, not content).

The docs deploy revalidates on merge to `main`. **Merge with a merge commit, not a squash.**

This pull request and its description were written by Isaac.