### PR TITLE
fix(docs): drop unnecessary dep pins, add npm retry resilience

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,14 @@
+# npm install resilience for the Deploy documentation CI job.
+#
+# The GitHub-hosted runners intermittently fail the TLS handshake to the
+# Databricks npm proxy ("Client network socket disconnected before secure TLS
+# connection was established"). The tarballs exist and serve fine — it is a
+# transient connection failure, not a missing/unmirrored package — so `npm ci`
+# just needs to retry through the blip instead of aborting the whole install on
+# the first reset. These keys only tune fetch retry/backoff; registry and auth
+# come from the CI's own config (NETRC / OIDC) and are intentionally not set here.
+fetch-retries=6
+fetch-retry-factor=2
+fetch-retry-mintimeout=15000
+fetch-retry-maxtimeout=120000
+fetch-timeout=300000

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3560,55 +3560,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/path-to-regexp": {
-      "version": "3.3.0",
-      "resolved": "https://npm-proxy.cloud.databricks.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
-      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/core/node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
-      "resolved": "https://npm-proxy.cloud.databricks.com/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "react-loadable": "*",
-        "webpack": ">=4.41.1 || 5.x"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/serve-handler": {
-      "version": "6.1.6",
-      "resolved": "https://npm-proxy.cloud.databricks.com/serve-handler/-/serve-handler-6.1.6.tgz",
-      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.0.0",
-        "content-disposition": "0.5.2",
-        "mime-types": "2.1.18",
-        "minimatch": "3.1.2",
-        "path-is-inside": "1.0.2",
-        "path-to-regexp": "3.3.0",
-        "range-parser": "1.2.0"
-      }
-    },
     "node_modules/@docusaurus/cssnano-preset": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
@@ -12764,6 +12715,18 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -15362,6 +15325,22 @@
         "react": "*"
       }
     },
+    "node_modules/react-loadable-ssr-addon-v5-slorber": {
+      "version": "1.0.3",
+      "resolved": "https://npm-proxy.cloud.databricks.com/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "react-loadable": "*",
+        "webpack": ">=4.41.1 || 5.x"
+      }
+    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -15517,19 +15496,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/recursive-readdir/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://npm-proxy.cloud.databricks.com/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/regenerate": {
@@ -16227,6 +16193,27 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://npm-proxy.cloud.databricks.com/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "license": "MIT"
     },
     "node_modules/serve-index": {
       "version": "1.9.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -32,11 +32,6 @@
     "playwright": "^1.58.0",
     "raw-loader": "^4.0.2"
   },
-  "overrides": {
-    "serve-handler": "6.1.6",
-    "react-loadable-ssr-addon-v5-slorber": "1.0.1",
-    "minimatch": "3.1.2"
-  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## Docs-deploy hotfix #3 — the actual fix (`beta/0.5.0` → `main`)

Supersedes the pinning approach in #73 and #74. One commit: `f26439fb`.

### What the earlier fixes got wrong
#73 and #74 pinned `serve-handler`, `react-loadable-ssr-addon-v5-slorber`, and `minimatch` back to older versions, assuming the proxy hadn't mirrored the newer ones. It had. Probing the Databricks npm proxy directly, **every version involved serves fine** (HTTP 200, sub-second):

| package | result |
|---|---|
| serve-handler 6.1.7 | 200, 14 KB, 0.30s |
| react-loadable-ssr-addon-v5-slorber 1.0.3 | 200, 21 KB, 0.55s |
| minimatch 3.1.5 | 200, 13 KB, 0.25s |
| minimatch 3.1.2 (what #74 pinned to, and what then failed) | 200, 12 KB, 0.34s |
| @docusaurus/plugin-client-redirects 3.9.2 | 200, 13 KB, 0.73s |

The third deploy failure hit `minimatch-3.1.2` — the exact version #74 pinned to. Pinning was chasing a symptom.

### Actual root cause
The CI error is literal: **"Client network socket disconnected before secure TLS connection was established."** Intermittent TLS-handshake flakiness between the GitHub-hosted runners and the proxy, on whichever package `npm ci` is fetching at the time. A pin can't fix a connection that resets before it opens.

### Fix
- **Revert the pins** (`serve-handler` / `react-loadable-ssr-addon` / `minimatch`) back to the naturally-resolved versions.
- **Add `docs/.npmrc`** with fetch retry/backoff (`fetch-retries=6`, exponential backoff) so `npm ci` rides through a transient reset instead of aborting on the first one. Only retry/timeout keys are set — registry and auth stay with the CI config.

If a rare, longer proxy blip still slips through the retries, a plain re-run clears it. **Merge with a merge commit, not a squash.**

This pull request and its description were written by Isaac.