### PR TITLE
fix(docs): npm CI resilience for proxy TLS resets (maxsockets, retries, cache)

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -3,20 +3,24 @@
 # The GitHub-hosted runners intermittently fail the TLS handshake to the
 # Databricks npm proxy ("Client network socket disconnected before secure TLS
 # connection was established"). The tarballs exist and serve fine — it is a
-# transient connection failure, not a missing/unmirrored package — so `npm ci`
-# just needs to retry through the blip instead of aborting the whole install on
-# the first reset. These keys tune fetch retry/backoff and connection
-# concurrency; registry and auth come from the CI's own config (NETRC / OIDC)
-# and are intentionally not set here.
+# transient connection failure, not a missing/unmirrored package. These keys
+# tune connection concurrency, fetch retry/backoff, and drop needless network
+# calls; registry and auth come from the CI's own config (NETRC / OIDC) and are
+# intentionally not set here. (Forcing IPv4 is NOT needed: the proxy is
+# IPv4-only — no AAAA record — so there is no IPv6 handshake to avoid.)
 #
 # maxsockets caps how many TLS handshakes npm opens to the proxy at once
 # (default ~15). The reset hitting random packages is the signature of a proxy
-# dropping connections under that parallelism, so a low cap trades a little
-# speed for far fewer resets. It stacks with the retries below and the
-# setup-node npm cache (which warms across runs on the same lockfile).
-maxsockets=5
-fetch-retries=6
+# dropping connections under that parallelism, so a lower cap trades a little
+# speed for fewer resets. Stacks with the retries below and the setup-node npm
+# cache (cache: "npm", keyed on the lockfile), which warms across runs.
+maxsockets=10
+fetch-retries=5
 fetch-retry-factor=2
 fetch-retry-mintimeout=15000
 fetch-retry-maxtimeout=120000
 fetch-timeout=300000
+# Drop the post-install audit and funding lookups — extra registry calls that
+# add nothing to a docs build and are two more chances to hit the flaky proxy.
+audit=false
+fund=false

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -5,8 +5,16 @@
 # connection was established"). The tarballs exist and serve fine — it is a
 # transient connection failure, not a missing/unmirrored package — so `npm ci`
 # just needs to retry through the blip instead of aborting the whole install on
-# the first reset. These keys only tune fetch retry/backoff; registry and auth
-# come from the CI's own config (NETRC / OIDC) and are intentionally not set here.
+# the first reset. These keys tune fetch retry/backoff and connection
+# concurrency; registry and auth come from the CI's own config (NETRC / OIDC)
+# and are intentionally not set here.
+#
+# maxsockets caps how many TLS handshakes npm opens to the proxy at once
+# (default ~15). The reset hitting random packages is the signature of a proxy
+# dropping connections under that parallelism, so a low cap trades a little
+# speed for far fewer resets. It stacks with the retries below and the
+# setup-node npm cache (which warms across runs on the same lockfile).
+maxsockets=5
 fetch-retries=6
 fetch-retry-factor=2
 fetch-retry-mintimeout=15000


### PR DESCRIPTION
## Docs-deploy resilience (`beta/0.5.0` → `main`)

Follow-up to #75. `docs/.npmrc` only (commits `1fb5b375`, `a88a50c2`).

### Problem
The **Deploy documentation** build repeatedly fails at **Install dependencies** with *"Client network socket disconnected before secure TLS connection was established"* on random packages. Probing the proxy directly, every tarball serves fine (HTTP 200, sub-second) — so it's **intermittent TLS-handshake flakiness between the GitHub runners and the proxy**, not missing packages. The #75 retries engaged (install ran ~24 min vs the ~8-min hard deaths) but a sustained blip still exhausted them on one package.

### Fix — resilience knobs in `docs/.npmrc`
```
maxsockets=10                 # fewer parallel TLS handshakes than npm's ~15 default
fetch-retries=5               # ride through a transient reset instead of aborting
fetch-retry-factor=2
fetch-retry-mintimeout=15000
fetch-retry-maxtimeout=120000
fetch-timeout=300000
audit=false                   # drop the post-install audit registry call
fund=false                    # drop the funding lookup
```
The reset hitting *random* packages is the signature of a proxy dropping connections under npm's default parallelism, so capping `maxsockets` attacks the cause; retries are the safety net; `audit`/`fund=false` remove two needless registry calls.

### Already in place (no change needed)
- **npm cache** — `deploy-docs.yml` already uses `setup-node` with `cache: "npm"` keyed on `docs/package-lock.json`. Successful tarballs persist and restore next run, so re-runs re-fetch only the misses. `.npmrc` edits don't change the lockfile hash, so this commit's deploy still restores the prior runs' warm cache.
- **`npm ci`** (not `npm install`) — already used.

### Considered and rejected
- **Force IPv4** (a common TLS-reset remedy): N/A here — `npm-proxy.cloud.databricks.com` is **IPv4-only** (no AAAA record), so there's no IPv6 handshake to avoid.
- **Switch to pnpm**: too invasive for a docs build (new lockfile, strict node_modules can break Docusaurus plugins); reserve as a last resort.

If a severe outage still beats all layers, a plain re-run — now cache-warm — should clear it. **Merge with a merge commit, not a squash.**

This pull request and its description were written by Isaac.