### PR TITLE
VectorX ST benchmarking + docs positioning refresh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "jq -r '.tool_input.command' | grep -qE 'git[[:space:]]+(push|pp|stack[[:space:]]+push)' && jq -nc '{systemMessage: \"Reminder: run gbx:review:round (scoped Isaac Review) before pushing if these changes have not been reviewed.\"}'; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file is the entry point for any Claude (or Cursor) session in this repo. Us
 
 ## Project
 
-**GeoBrix** is a high-performance spatial processing library — a modern successor to [DBLabs Mosaic](https://databrickslabs.github.io/mosaic/), targeting Databricks Runtime (DBR 17.3, 18, or 19). Current version **0.5.0** (beta). APIs may break to stabilize, and there are **no function aliases** — one canonical name per function. See `docs/docs/release-notes.mdx` for breaking changes.
+**GeoBrix** is a high-performance spatial processing library — a modern successor to [DBLabs Mosaic](https://databrickslabs.github.io/mosaic/), targeting Databricks Runtime (DBR 17.3, 18, or 19). Current version **0.5.0**. APIs may break to stabilize, and there are **no function aliases** — one canonical name per function. See `docs/docs/release-notes.mdx` for breaking changes.
 
 Heavy code is Scala/Spark (JAR); lightweight bindings are Python (wheel) and SQL, both wrapping the Scala columnar expressions via Spark Connect.
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@
 
 ## Packages
 
-<img src="resources/images/brand/RasterX.png" width="18%" /> <img src="resources/images/brand/GridX.png" width="18%" /> <img src="resources/images/brand/VectorX.png" width="18%" />
+<img src="resources/images/brand/RasterX.png" width="18%" /> <img src="resources/images/brand/GridX.png" width="18%" /> <img src="resources/images/brand/VectorX.png" width="18%" /> <img src="resources/images/brand/VizX.png" width="18%" />
 
-- **[RasterX](https://databrickslabs.github.io/geobrix/docs/api/raster-functions)** — raster I/O and analytics (gap-filling; the platform has no built-in raster). **Both tiers** — lightweight `pyrx` and heavyweight Scala.
-- **[GridX](https://databrickslabs.github.io/geobrix/docs/api/gridx-functions)** — BNG, Quadbin, and custom grids (pairs with native H3 for global hex). **Both tiers** — lightweight `pygx` and heavyweight Scala.
-- **[VectorX](https://databrickslabs.github.io/geobrix/docs/api/vectorx-functions)** — MVT tiles, TIN surfaces, and legacy-geometry migration on top of native ST. **Both tiers** — lightweight `pyvx` and heavyweight Scala.
+- **[RasterX](https://databrickslabs.github.io/geobrix/docs/api/raster-functions)** — full-spectrum raster I/O and analytics (gap-filling; the platform has no built-in raster): reprojection, terrain, spectral indices, XYZ/PMTiles tiling, and H3/quadbin/BNG aggregation, plus **virtual tiles** and a **COG-preparation lane** for memory-safe processing of multi-gigabyte rasters. **Both tiers** — lightweight `pyrx` and heavyweight Scala.
+- **[GridX](https://databrickslabs.github.io/geobrix/docs/api/gridx-functions)** — discrete global grids: British National Grid, CARTO quadbin, and custom user-defined grids — cell math, k-ring/k-loop, polyfill, tessellation, and grid-aware aggregation (pairs with native H3 for global hex). **Both tiers** — lightweight `pygx` and heavyweight Scala.
+- **[VectorX](https://databrickslabs.github.io/geobrix/docs/api/vectorx-functions)** — vector operations that augment the native ST functions: MVT tile encoding, TIN elevation surfaces, authority-string CRS transforms, antimeridian handling, and distributed-shapely geometry validity, cleaning & coverage-validity, plus legacy-geometry migration. **Both tiers** — lightweight `pyvx` and heavyweight Scala.
+- **[VizX](https://databrickslabs.github.io/geobrix/docs/api/vizx)** — tier-agnostic notebook visualization: render raster tiles/files, whole VRT mosaics (`plot_mosaic`), and PMTiles/COG archives, and turn Spark geometry/H3-cell/grid DataFrames into GeoPandas for static & interactive maps. **Python-only** (no SQL); works with either tier.
 
 All SQL functions register with a `gbx_` prefix (e.g. `gbx_rst_clip`, `gbx_bng_cellarea`, `gbx_st_asmvt`) so usage is clearly attributable to GeoBrix on classic compute. Python/Scala bindings mirror the names. See [benchmarks](https://databrickslabs.github.io/geobrix/docs/api/benchmarking) for light-vs-heavy timings. 
 

--- a/docs/docs/api/benchmarking.mdx
+++ b/docs/docs/api/benchmarking.mdx
@@ -920,7 +920,7 @@ non-constraint diagonals), **per-cell surface closeness within 1e-6** for elevat
 Cluster spark-path results (DBR 17.3 LTS; median wall-clock of one full distributed iteration over
 *N* tiles; same corpus both tiers):
 
-| Function | Tiles/iter | Heavy (s) | Light (s) | Light speedup |
+| Function | Geoms/iter | Heavy (s) | Light (s) | Light speedup |
 |---|---|---|---|---|
 | `st_interpolateelevationgeom` | 125 | 0.49 | 0.56 | 0.88× |
 | `st_legacyaswkb` | 1,000 | 0.39 | 0.48 | 0.82× |
@@ -932,6 +932,59 @@ on legacy migration and elevation interpolation (~0.75–0.88×) and ~1.7× behi
 the gap is the JVM↔Python serialization of the geometry arrays crossing the UDTF boundary (the same
 boundary cost seen for other byte-heavy lightweight UDTFs), not the triangulation compute itself.
 Decoded-output parity holds across both tiers (enforced by the cross-tier parity test suite, above).
+
+### Geometry validity & cleaning — scalar ST functions (lightweight tier only)
+
+The validity-checking and geometry-cleaning functions — `st_removeRepeatedPoints`, `st_snap`,
+`st_makeValid`, `st_node`, `st_simplifyPreserveTopology`, `st_reducePrecision`, `st_explainValidity`,
+`st_transformCrs`, `st_shiftLongitude`, `st_wrapX`, `st_split`, `st_setCrs`, and `st_crs` — are
+lightweight-tier scalar operations with no heavyweight equivalent. The benchmark measures **per-geometry latency** on a
+distributed job (1,000 geometries per function) and reports **absolute throughput** (geometries/sec)
+rather than a heavy-vs-light ratio. All are pure-Python using `shapely` for geometry validation,
+transformation, and cleaning.
+
+> **Environment:** Databricks · DBR 18.x · lightweight tier only · 1,000 geometries per function
+> · 20 workers · spark-path whole-job wall-clock median, one measured iteration. **Unit: per-geometry
+> latency (milliseconds) and throughput (geometries/second).**
+
+| Function | ms/geometry | geoms/sec |
+|---|---|---|
+| `st_removerepeatedpoints` | 0.90 | 1106 |
+| `st_snap` | 0.91 | 1096 |
+| `st_makevalid` | 0.91 | 1095 |
+| `st_node` | 0.93 | 1074 |
+| `st_simplifypreservetopology` | 0.95 | 1048 |
+| `st_reduceprecision` | 0.97 | 1034 |
+| `st_explainvalidity` | 1.02 | 982 |
+| `st_transformcrs` | 1.06 | 942 |
+| `st_shiftlongitude` | 1.08 | 923 |
+| `st_wrapx` | 1.08 | 923 |
+| `st_setcrs` | 1.12 | 895 |
+| `st_crs` | 1.24 | 810 |
+| `st_split` | 1.77 | 565 |
+
+These lightweight-tier functions reach **~800–1100 geometries/second per-core** (at 20 workers),
+covering the common validity repair and coordinate-transform use cases for vector-data pipelines.
+The UDF boundary cost is amortized across a batch in the Arrow `pandas_udf` path, so throughput is
+roughly uniform across the set.
+
+### Coverage validity — grouped aggregates (`st_coverageisvalid`, `st_coverageinvalidedges`)
+
+`st_coverageisvalid` and `st_coverageinvalidedges` are **grouped-aggregates**: they validate a whole
+polygon *coverage* (overlaps and gaps between polygons) rather than one geometry per row. The
+benchmark aggregates a coverage of overlapping polygons and times it per group, so the unit is a
+**coverage group**, not a single geometry. Lightweight tier only (no heavyweight equivalent).
+
+> **Environment:** Databricks · DBR 18.x · lightweight tier only · 1,000 coverage groups · 20 workers
+> · spark-path whole-job wall-clock median, one measured iteration. **Unit: per coverage group.**
+
+| Function | ms/group | groups/sec |
+|---|---|---|
+| `st_coverageinvalidedges` | 1.56 | 639 |
+| `st_coverageisvalid` | 2.41 | 415 |
+
+`st_asmvt_pyramid` (a per-feature MVT tiling UDTF) is not yet in the benchmark suite; the scalar MVT
+aggregator `st_asmvt` is covered under [MVT encoding](#mvt-encoding-st_asmvt) above.
 
 </TabItem>
 

--- a/docs/docs/api/benchmarking.mdx
+++ b/docs/docs/api/benchmarking.mdx
@@ -906,8 +906,25 @@ runs **at parity with the heavyweight JVM/OGR aggregator** (~6% apart). Both enc
 decoded tiles are **feature-equivalent** — a hard parity gate; the benchmark fails if the tiers
 diverge. Tiles compose with `pmtiles_agg` for end-to-end publishing.
 
-`st_asmvt_pyramid` (a per-feature MVT tiling UDTF) is not yet in the benchmark suite; the scalar MVT
-aggregator `st_asmvt` is benchmarked above.
+### MVT pyramid tiling (`st_asmvt_pyramid`)
+
+`st_asmvt_pyramid` is a per-feature MVT tiling **UDTF**: each input geometry fans out to one
+`(z, x, y, mvt)` row per tile it intersects across a zoom range. The benchmark drives it in the
+same distributed shape it runs in production — a SQL `LATERAL` table-function join over a WKB
+geometry column — timing `SELECT t.* FROM geoms AS d, LATERAL gbx_st_asmvt_pyramid(d.geom, NULL,
+0, 5, 'layer') AS t` whole-job. It is **light-only** (no heavyweight counterpart), so this is an
+absolute lightweight number rather than a ratio.
+
+> **Environment:** Databricks · DBR 18 · 20 workers · 1000 input geometries → z 0–5 pyramid ·
+> whole-job wall-clock median.
+
+| Tier | Function | Input | Median | Throughput |
+|---|---|---|---|---|
+| lightweight | `pyvx.st_asmvt_pyramid` | 1000 geoms → z 0–5 tiles | ~2.6 s | **~390 geoms/s** |
+
+At **~2.6 ms per input geometry**, the per-geometry cost covers the full zoom-pyramid fan-out (each
+feature emitting a tile at every intersecting level z 0–5) plus MVT-encoding every output tile — so
+it runs higher than the scalar per-feature encoders, as expected for a one-to-many tiling operation.
 
 ### TIN & legacy migration (`st_triangulate`, `st_interpolateelevation*`, `st_legacyaswkb`)
 

--- a/docs/docs/api/benchmarking.mdx
+++ b/docs/docs/api/benchmarking.mdx
@@ -906,6 +906,9 @@ runs **at parity with the heavyweight JVM/OGR aggregator** (~6% apart). Both enc
 decoded tiles are **feature-equivalent** — a hard parity gate; the benchmark fails if the tiers
 diverge. Tiles compose with `pmtiles_agg` for end-to-end publishing.
 
+`st_asmvt_pyramid` (a per-feature MVT tiling UDTF) is not yet in the benchmark suite; the scalar MVT
+aggregator `st_asmvt` is benchmarked above.
+
 ### TIN & legacy migration (`st_triangulate`, `st_interpolateelevation*`, `st_legacyaswkb`)
 
 The constrained-Delaunay TIN generators (`st_triangulate`, `st_interpolateelevationbbox`,
@@ -982,9 +985,6 @@ benchmark aggregates a coverage of overlapping polygons and times it per group, 
 |---|---|---|
 | `st_coverageinvalidedges` | 1.56 | 639 |
 | `st_coverageisvalid` | 2.41 | 415 |
-
-`st_asmvt_pyramid` (a per-feature MVT tiling UDTF) is not yet in the benchmark suite; the scalar MVT
-aggregator `st_asmvt` is covered under [MVT encoding](#mvt-encoding-st_asmvt) above.
 
 </TabItem>
 

--- a/docs/docs/api/benchmarking.mdx
+++ b/docs/docs/api/benchmarking.mdx
@@ -920,9 +920,9 @@ absolute lightweight number rather than a ratio.
 
 | Tier | Function | Input | Median | Throughput |
 |---|---|---|---|---|
-| lightweight | `pyvx.st_asmvt_pyramid` | 1000 geoms → z 0–5 tiles | ~2.6 s | **~390 geoms/s** |
+| lightweight | `pyvx.st_asmvt_pyramid` | 1000 geoms → z 0–5 tiles | ~2.4 s | **~420 geoms/s** |
 
-At **~2.6 ms per input geometry**, the per-geometry cost covers the full zoom-pyramid fan-out (each
+At **~2.4 ms per input geometry**, the per-geometry cost covers the full zoom-pyramid fan-out (each
 feature emitting a tile at every intersecting level z 0–5) plus MVT-encoding every output tile — so
 it runs higher than the scalar per-feature encoders, as expected for a one-to-many tiling operation.
 

--- a/docs/docs/api/gridx-functions.mdx
+++ b/docs/docs/api/gridx-functions.mdx
@@ -23,10 +23,11 @@ Complete reference for all GridX discrete-global-grid functions — CARTO Quadbi
 
 ## Overview
 
-GridX is GeoBrix's discrete-global-grid indexing package. As of v0.4.0 it ships two grid systems: **CARTO quadbin v0** for web-mercator-aligned global indexing and **British National Grid (BNG)** for Great Britain workloads.
+GridX is GeoBrix's discrete-global-grid indexing package. It ships **CARTO quadbin v0** for web-mercator-aligned global indexing, **British National Grid (BNG)** for Great Britain workloads, and **custom user-defined grids** — and pairs with the product's native H3 for global hex indexing.
 
 - **Quadbin (CARTO v0)** — a global zoom-indexed tile addressing scheme aligned with web-mercator slippy maps, compatible with CARTO's CDB_QuadKey IDs. Cell `(z, x, y)` coordinates align with the same XYZ tile grid that PMTiles / MVT readers consume — natural for slippy-map heatmaps and global analytics.
 - **BNG (British National Grid)** — the Ordnance Survey National Grid (OSGB36) used in Great Britain for spatial indexing and location-based services. Specialized for UK-based spatial data.
+- **Custom user-defined grids** — define a regional or equal-area grid and get cell math, polyfill, and tessellation on it.
 
 :::note Registration and import paths
 - Quadbin: `databricks.labs.gbx.gridx.quadbin` (Python) / `com.databricks.labs.gbx.gridx.quadbin` (Scala)
@@ -44,6 +45,7 @@ Use `RegisterBatch` with `functions=gridx.quadbin` or `functions=gridx.bng` to r
 - **Multi-Resolution Support**: Work with different grid resolutions (BNG: 1–6 integer indices; Quadbin: zoom 0..26)
 - **K-Ring / K-Loop Neighbourhoods**: Filled rings and hollow rings for both grid systems
 - **Polyfill and Tessellation**: Cover geometries with cells; tessellation returns per-cell clipped chip geometries
+- **Custom Grids**: Define your own regional or equal-area grid systems (cell math, polyfill, tessellation)
 
 ## Setup {#setup}
 

--- a/docs/docs/api/overview.mdx
+++ b/docs/docs/api/overview.mdx
@@ -21,7 +21,7 @@ GeoBrix provides four specialized packages for different spatial processing need
 
 ### <img src={RasterXIcon} alt="RasterX" style={{height: '88px', width: 'auto', verticalAlign: 'middle'}} /> {#rasterx}
 
-Full-spectrum raster processing for Databricks — successor to Mosaic raster, plus terrain analysis, spectral indices, tile publishing, and vector↔raster bridging.
+Full-spectrum raster processing for Databricks — successor to Mosaic raster, plus terrain analysis, spectral indices, tile publishing, vector↔raster bridging, and memory-safe large-raster processing (virtual tiles + a COG-preparation lane).
 
 - Process GeoTIFF and other GDAL-supported raster formats
 - Raster algebra, transformations, clipping, reprojection
@@ -33,6 +33,7 @@ Full-spectrum raster processing for Databricks — successor to Mosaic raster, p
 - Web-mercator XYZ tile output (`to_webmercator`, `tilexyz`, `xyzpyramid`)
 - Grid aggregations to H3 or CARTO quadbin v0 cells
 - COG output, proximity, contour, viewshed
+- Virtual tiles — bytes-free windowed reads for multi-gigabyte rasters; COG-preparation lane (`file_gbx` + `cog_gbx`) and VRT mosaics
 
 [Raster Function Reference →](./raster-functions)
 
@@ -40,10 +41,11 @@ Full-spectrum raster processing for Databricks — successor to Mosaic raster, p
 
 ### <img src={GridXIcon} alt="GridX" style={{height: '88px', width: 'auto', verticalAlign: 'middle'}} /> {#gridx}
 
-Spatial indexing across multiple discrete-global-grid systems: **BNG** (British National Grid) for Great Britain workloads and **CARTO quadbin v0** for web-mercator-aligned analytics.
+Spatial indexing across multiple discrete-global-grid systems: **BNG** (British National Grid) for Great Britain workloads, **CARTO quadbin v0** for web-mercator-aligned analytics, and **custom user-defined grids** — pairing with the product's native H3 for global hex.
 
 - British National Grid (BNG) — 21 functions covering cell math, kring/kloop, polyfill, tessellation, aggregators, and generators
 - CARTO Quadbin v0 — 9 functions (`pointascell`, `aswkb`, `centroid`, `resolution`, `polyfill`, `kring`, `tessellate`, `cellunion`, `distance`); cell IDs are 64-bit Long, aligned with the web-mercator XYZ tile grid
+- Custom user-defined grids — define a regional or equal-area grid and get cell math, polyfill, and tessellation on it
 - Cell area calculations, k-ring / k-loop neighborhoods, geometry-to-cell tessellation
 
 [GridX Function Reference →](./gridx-functions)
@@ -52,11 +54,14 @@ Spatial indexing across multiple discrete-global-grid systems: **BNG** (British 
 
 ### <img src={VectorXIcon} alt="VectorX" style={{height: '88px', width: 'auto', verticalAlign: 'middle'}} /> {#vectorx}
 
-Augments Databricks built-in `ST_*` functions with vector-tile encoding, TIN surface modeling, and legacy-Mosaic migration helpers.
+Augments the product's native `ST_*` functions with vector-tile encoding, TIN surface modeling, authority-string CRS transforms, antimeridian handling, and distributed-shapely geometry validity, cleaning, and coverage-validity — plus legacy-geometry migration.
 
-- Mapbox Vector Tile (MVT) encoding via `st_asmvt` aggregator
-- Vector tile pyramid via `st_asmvt_pyramid` generator — composes with `pmtiles_agg` for end-to-end publishing
-- TIN surface modeling — `st_triangulate` plus `st_interpolateelevationbbox` / `st_interpolateelevationgeom` (constrained-Delaunay triangulation and grid elevation interpolation from Z-valued points)
+- Mapbox Vector Tile (MVT) encoding via `st_asmvt` aggregator + `st_asmvt_pyramid` generator (composes with `pmtiles_agg` for end-to-end publishing)
+- TIN surface modeling — `st_triangulate`, `st_interpolateelevationbbox`, `st_interpolateelevationgeom` (constrained-Delaunay triangulation and grid elevation interpolation from Z-valued points)
+- CRS strings — `st_crs` / `st_setcrs` / `st_transformcrs` read, stamp, and reproject by authority-string CRS (ESRI codes, WKT, PROJ4 — not just an EPSG integer)
+- Geometry validity & cleaning (lightweight) — `st_makevalid`, `st_explainvalidity`, and topology-safe cleaning (`st_simplifypreservetopology`, `st_removerepeatedpoints`, `st_reduceprecision`, `st_node`, `st_snap`)
+- Coverage validity (lightweight) — `st_coverageisvalid`, `st_coverageinvalidedges`, `coverage_simplify`
+- Antimeridian handling (lightweight) — `st_shiftlongitude`, `st_wrapx`, `st_split`
 - Legacy Mosaic geometry conversion (migrate without installing Mosaic)
 - OGR-based reader data sources (Shapefile, GeoJSON, GeoPackage, FileGDB)
 
@@ -66,9 +71,11 @@ Augments Databricks built-in `ST_*` functions with vector-tile encoding, TIN sur
 
 ### <img src={VizXIcon} alt="VizX" style={{height: '88px', width: 'auto', verticalAlign: 'middle'}} /> {#vizx}
 
-Tier-agnostic visualization helpers for inspecting GeoBrix outputs in a notebook — Python-only, no SQL functions.
+Tier-agnostic visualization helpers for inspecting GeoBrix outputs in a notebook — render rasters and mosaics, and turn Spark geometry / H3-cell / grid DataFrames into GeoPandas for static & interactive maps. Python-only, no SQL functions.
 
 - Raster plotting (`plot_raster` / `plot_file`) with auto-decimation and percentile stretch, including coverage-depth and mask-layer composites for multi-band presence stacks
+- VRT mosaic rendering (`plot_mosaic`) — a whole mini-COG mosaic (from the `cog_gbx` `vrtMosaic` writer) as one memory-safe image, with a bbox viewport and optional h3 cell overlay
+- Multi-layer compositor (`plot_static` / `plot_interactive`) and PMTiles/COG viewers (`plot_pmtiles`, `plot_cog`, `pmtiles_info`)
 - Spark DataFrame → GeoPandas adapters (`as_gdf` / `cells_as_gdf` / `grid_as_gdf`) for `.plot()` / `.explore()` maps
 
 [VizX Reference →](./vizx)
@@ -102,7 +109,7 @@ Helpers for discovering and loading imagery from **SpatioTemporal Asset Catalog 
 | **Product Gap** | Full gap-filling | Specialized grids (BNG, quadbin) | Vector-tile encoding, legacy migration | Net-new | Supporting layer |
 | **GDAL Required** | Yes | No | Yes (readers + MVT) | No | No |
 | **Output Format** | Tile (struct) + arrays | Cell IDs (Long / String) + WKB | BINARY (MVT bytes), WKB | BINARY (PMTile blob) or file | Matplotlib figure / GeoDataFrame |
-| **Spark Surface** | 65+ SQL functions | 30+ SQL functions | 6+ SQL functions + DataSources | 1 UDAF + 1 DataSource | Python only (no SQL) |
+| **Spark Surface** | 129 SQL functions | 41 SQL functions | 21 SQL functions + DataSources | 1 UDAF + 1 DataSource | Python only (no SQL) |
 
 ## Choosing the Right Package
 
@@ -110,7 +117,7 @@ Helpers for discovering and loading imagery from **SpatioTemporal Asset Catalog 
 
 **Use GridX when:** working with British National Grid data; indexing global data into web-mercator-aligned quadbin cells; needing cell math (area, k-ring, polyfill, tessellation); building grid-aware aggregations or join keys.
 
-**Use VectorX when:** encoding features as Mapbox Vector Tiles; generating per-tile MVT layers; building TIN surfaces / interpolating elevation from Z-valued points; reading vector formats (Shapefile, GeoJSON, GeoPackage, FileGDB); migrating from DBLabs Mosaic.
+**Use VectorX when:** encoding features as Mapbox Vector Tiles; generating per-tile MVT layers; building TIN surfaces / interpolating elevation from Z-valued points; handling CRS by authority string or normalizing antimeridian-crossing geometries; repairing, cleaning, or coverage-validating geometry (lightweight); reading vector formats (Shapefile, GeoJSON, GeoPackage, FileGDB); migrating from DBLabs Mosaic.
 
 **Use PMTiles when:** publishing a tile pyramid (raster or vector) as a single static file; serving from S3/ABFS/GCS without a tile server; aggregating `(z, x, y, bytes)` rows into a deployable map.
 

--- a/docs/docs/api/performance.mdx
+++ b/docs/docs/api/performance.mdx
@@ -412,6 +412,28 @@ These functions are `pandas_udf`-backed (Arrow batch) scalar transforms: one inp
 | `gbx_rst_gridfrompoints` | `rst_gridfrompoints` |
 | `gbx_rst_dtmfromgeoms` | `rst_dtmfromgeoms` |
 
+**VectorX (pyvx) — geometry validity & cleaning**
+
+| SQL name | Python name | Operation |
+|---|---|---|
+| `gbx_st_makevalid` | `st_makevalid` | Repair invalid polygon/linestring geometry |
+| `gbx_st_removerepeatedpoints` | `st_removerepeatedpoints` | Remove consecutive duplicate vertices |
+| `gbx_st_snap` | `st_snap` | Snap vertices of one geometry to another within tolerance |
+| `gbx_st_node` | `st_node` | Node line crossings to vertices |
+| `gbx_st_simplifypreservetopology` | `st_simplifypreservetopology` | Simplify geometry while preserving topology |
+| `gbx_st_reduceprecision` | `st_reduceprecision` | Reduce coordinate precision to a grid |
+| `gbx_st_explainvalidity` | `st_explainvalidity` | Return `STRUCT` describing why a geometry is invalid (or empty struct if valid) |
+
+**VectorX (pyvx) — CRS & coordinate transformation**
+
+| SQL name | Python name | Operation |
+|---|---|---|
+| `gbx_st_transformcrs` | `st_transformcrs` | Reproject geometry from one CRS to another |
+| `gbx_st_setcrs` | `st_setcrs` | Assign a CRS to geometry (no reprojection) |
+| `gbx_st_crs` | `st_crs` | Extract CRS of a geometry as an EPSG code (integer) |
+| `gbx_st_shiftlongitude` | `st_shiftlongitude` | Shift longitude coordinates by ±180° (handle antimeridian wrapping) |
+| `gbx_st_wrapx` | `st_wrapx` | Normalize longitude to `[−180, 180]` or `[0, 360]` range |
+
 **VectorX (pyvx) — legacy-geometry migration**
 
 | SQL name | Python name | Operation |

--- a/docs/docs/api/raster-functions.mdx
+++ b/docs/docs/api/raster-functions.mdx
@@ -37,7 +37,7 @@ RasterX's lightweight tier is, in large part, **distributed rasterio** + a best-
 
 ## Overview
 
-RasterX is GeoBrix's raster data processing package, providing comprehensive tools for working with raster datasets such as satellite imagery, elevation models, and other gridded spatial data. It is a refactor and improvement of Mosaic raster functions, extended in v0.4.0 with terrain analysis, spectral indices, vector-raster bridging, web-mercator tile output, and quadbin grid aggregations. Since the Databricks product does not (yet) support anything built-in specifically for raster processing, RasterX provides a gap-filling capability for raster operations on the Databricks platform.
+RasterX is GeoBrix's raster data processing package, providing comprehensive tools for working with raster datasets such as satellite imagery, elevation models, and other gridded spatial data. It is a refactor and improvement of Mosaic raster functions, extended through v0.5.0 with terrain analysis, spectral indices, vector-raster bridging, web-mercator tile output, H3/quadbin/BNG grid aggregations, and — in v0.5.0 — **virtual tiles**, a **COG-preparation lane**, and **VRT mosaics** for memory-safe processing of multi-gigabyte rasters. Since the Databricks product does not (yet) support anything built-in specifically for raster processing, RasterX provides a gap-filling capability for raster operations on the Databricks platform.
 
 ## Key Features
 
@@ -51,11 +51,13 @@ RasterX is GeoBrix's raster data processing package, providing comprehensive too
 - **Spectral Indices**: EVI, SAVI, NDWI, NBR, NDVI, plus a generic dispatcher
 - **Vector-Raster Bridge**: Rasterize geometries, polygonize value regions
 - **Tile Publishing**: Web-mercator XYZ tile generation (PNG / JPEG / WebP)
-- **Grid Aggregations**: H3 and CARTO quadbin v0 cell aggregations
+- **Grid Aggregations**: H3, CARTO quadbin v0, and BNG cell aggregations
+- **Virtual Tiles**: Bytes-free windowed reads — process multi-gigabyte rasters without materializing them into executor memory
+- **COG Preparation & VRT Mosaics**: `file_gbx` + `cog_gbx` prepare spec-valid Cloud-Optimized GeoTIFFs and portable VRT mosaics for cheap windowed reads
 
 ## Function Categories
 
-RasterX exposes 87+ SQL functions (registered as `gbx_rst_*`; available in Python and Scala as `rst_*`), organized into the following categories (see [rasterx/functions.scala](https://github.com/databrickslabs/geobrix/blob/main/src/main/scala/com/databricks/labs/gbx/rasterx/functions.scala)):
+RasterX exposes 129 SQL functions (registered as `gbx_rst_*`; available in Python and Scala as `rst_*`), organized into the following categories (see [rasterx/functions.scala](https://github.com/databrickslabs/geobrix/blob/main/src/main/scala/com/databricks/labs/gbx/rasterx/functions.scala)):
 
 ![RasterX function categories — Constructors, Accessors, Aggregators, Generators, Operations, H3 Grid](../../../resources/images/diagrams/rasterx/rasterx-function-categories.png)
 

--- a/docs/docs/api/vectorx-functions.mdx
+++ b/docs/docs/api/vectorx-functions.mdx
@@ -16,7 +16,13 @@ import VectorXIcon from '../../../resources/images/brand/VectorX.png';
 
 # <img src={VectorXIcon} alt="VectorX" style={{height: '3em', width: 'auto', verticalAlign: 'middle', marginRight: '0.5rem'}} /> Function Reference
 
-VectorX augments the product's native `ST_*` functions with vector-tile encoding, TIN surface modeling, and legacy-geometry migration helpers. As of v0.5.0 it covers:
+## Overview
+
+VectorX augments the product's native `ST_*` functions with vector-tile encoding, TIN surface modeling, authority-string CRS handling, antimeridian normalization, distributed-shapely geometry validity, cleaning, and coverage-validity, and legacy-geometry migration.
+
+## Key Features
+
+As of v0.5.0 it covers:
 
 - **Vector tile encoding** — `gbx_st_asmvt` aggregator + `gbx_st_asmvt_pyramid` generator for publishing Mapbox Vector Tile (MVT) layers, available in **both** the lightweight (`pyvx`) and heavyweight (`vectorx`) tiers
 - **TIN surface modeling** — `gbx_st_triangulate`, `gbx_st_interpolateelevationbbox`, and `gbx_st_interpolateelevationgeom` for Delaunay triangulation and grid elevation interpolation from Z-valued points, in **both** tiers (with a `constrained`/`conforming` mode selector)

--- a/docs/docs/api/vizx.mdx
+++ b/docs/docs/api/vizx.mdx
@@ -7,6 +7,8 @@ import VizXIcon from '../../../resources/images/brand/VizX.png';
 
 # <img src={VizXIcon} alt="VizX" style={{height: '3em', width: 'auto', verticalAlign: 'middle', marginRight: '0.5rem'}} /> VizX
 
+## Overview
+
 `databricks.labs.gbx.vizx` renders rasters and turns Spark DataFrames into GeoDataFrames for interactive maps. It is **tier-agnostic** — the raster plotters take tile bytes (use them with `pyrx` *or* `rasterx` tiles), and the vector adapters take any Spark DataFrame.
 
 These are driver-side, single-node helpers for inspecting results in a notebook — not distributed operations. They collect to the driver, so the vector adapters guard the collect with `max_rows`.
@@ -14,6 +16,15 @@ These are driver-side, single-node helpers for inspecting results in a notebook 
 :::note Opt-in extra
 `gbx.vizx` requires `geobrix[vizx]`, which pulls in `matplotlib`, `geopandas`, `folium`, and `mapclassify`. The package itself imports only `matplotlib` (raster rendering) and `geopandas` (the GeoDataFrame adapters); `folium` + `mapclassify` are used by `plot_interactive` / `GeoDataFrame.explore()` for interactive maps.
 :::
+
+## Key Features
+
+- **Raster plotting** — `plot_raster` / `plot_file` render tile bytes or files (single-band, RGB, percentile stretch, coverage-depth, and mask-layer composites)
+- **VRT mosaic rendering** — `plot_mosaic` renders a whole mini-COG VRT mosaic (from the `cog_gbx` `vrtMosaic` writer) as one memory-safe georeferenced image, with a bbox viewport and an optional h3 cell overlay
+- **DataFrame → GeoPandas adapters** — `as_gdf` / `cells_as_gdf` / `grid_as_gdf` turn Spark geometry, H3-cell, and gridspec DataFrames into GeoDataFrames for `.plot()` / `.explore()`
+- **Multi-layer compositor** — `plot_static` / `plot_interactive` overlay vector, raster, grid, and PMTiles layers in a single map
+- **PMTiles & COG viewers** — `plot_pmtiles`, `plot_cog`, and `pmtiles_info` inspect and render archives inline
+- **Tier-agnostic, Python-only** — works with `pyrx` or `rasterx` tiles; a driver-side notebook helper, not a SQL/Spark package
 
 ## Installation
 
@@ -38,6 +49,7 @@ from databricks.labs.gbx.vizx import (
     plot_interactive,
     plot_pmtiles,
     plot_cog,
+    plot_mosaic,
     as_gdf,
     cells_as_gdf,
     grid_as_gdf,
@@ -52,7 +64,7 @@ from databricks.labs.gbx.pmtiles import pmtiles_info
 | [Multi-Layer Compositor](./vizx-layers) | `plot_static` / `plot_interactive` with multiple layers; embed-size ladder; audit; simplify | Overlaying vector, raster, grid, and PMTiles layers in one map |
 | [PMTiles Viewers](./vizx-pmtiles) | `pmtiles_info`, `plot_pmtiles`, `plot_cog` | Inspecting and rendering PMTiles archives and COGs inline |
 | [Vector](./vizx-vector) | `plot_interactive` (single-layer), `plot_static` (single-layer), `as_gdf`, `cells_as_gdf`, `grid_as_gdf` | Interactive and static single-layer maps; converting DataFrames to GeoDataFrames |
-| [Raster](./vizx-raster) | `plot_raster`, `plot_file`, `plot_mask_layers`, escape hatches | Rendering raster tiles from bytes or disk |
+| [Raster](./vizx-raster) | `plot_raster`, `plot_file`, `plot_mask_layers`, `plot_mosaic`, escape hatches | Rendering raster tiles from bytes or disk, and whole VRT mosaics |
 
 ## Next steps
 

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -53,7 +53,7 @@ function HomepageFeatures() {
         <div className="row">
           <Feature
             title="RasterX"
-            description="Satellite imagery, elevation models, and gridded data — reprojection, terrain analysis, spectral indices, XYZ/PMTiles tiling, and H3/quadbin aggregation. In large part, distributed rasterio + best-of-breed raster packages."
+            description="Satellite imagery, elevation models, and gridded data — reprojection, terrain analysis, spectral indices, XYZ/PMTiles tiling, and H3/quadbin aggregation. Virtual tiles and a COG-preparation lane process multi-gigabyte rasters memory-safely. In large part, distributed rasterio + best-of-breed raster packages."
             link="/docs/api/raster-functions"
           />
           <Feature
@@ -63,7 +63,7 @@ function HomepageFeatures() {
           />
           <Feature
             title="VectorX"
-            description="Mapbox Vector Tile encoding, TIN elevation surfaces, and legacy Mosaic geometry migration to Databricks spatial types."
+            description="Vector operations that augment the native ST functions — Mapbox Vector Tile encoding, TIN elevation surfaces, authority-string CRS transforms, antimeridian handling, and distributed-shapely geometry validity, cleaning, and coverage-validity."
             link="/docs/api/vectorx-functions"
           />
         </div>

--- a/python/geobrix/src/databricks/labs/gbx/bench/compare.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/compare.py
@@ -400,6 +400,19 @@ def pyrx_implemented() -> "frozenset[str]":
     return frozenset(names)
 
 
+def registered_raster() -> "frozenset[str]":
+    """Registered raster (`rst_*`) function names — the scope `pyrx_implemented`
+    covers.
+
+    ``spec.registered_rst()`` spans `rst_*` AND `st_*` (it is the full bench-registry
+    coverage set). The `st_*` functions are pyvx/vector bindings with no pyrx (light
+    *raster*) definition, so raster parity/coverage reporting must exclude them or the
+    functional-parity gap would wrongly flag every `st_*` function as "no lightweight
+    implementation" (they are pyvx-implemented, just not pyrx).
+    """
+    return frozenset(n for n in spec.registered_rst() if n.startswith("rst_"))
+
+
 def coverage_block(cells) -> str:
     """Build the neutral 'Coverage & parity' markdown section.
 
@@ -407,7 +420,7 @@ def coverage_block(cells) -> str:
     win counts, the computed functional-parity gap (registered minus pyrx-
     implemented), and the registered functions not yet benchmarked.
     """
-    registered = spec.registered_rst()
+    registered = registered_raster()
     implemented = pyrx_implemented()
     n_registered = len(registered)
 
@@ -513,7 +526,7 @@ def scorecard_from_store(
     if specs_by_name is None:
         specs_by_name = {s.name: s for s in _spec.select(set="full")}
 
-    registered = spec.registered_rst()
+    registered = registered_raster()
     implemented = pyrx_implemented()
     n_registered = len(registered)
 

--- a/python/geobrix/src/databricks/labs/gbx/bench/datagen.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/datagen.py
@@ -329,12 +329,196 @@ def generate_corpus(
     return corpus
 
 
+def _gen_invalid_geometries(seed: int, count: int = 16) -> list:
+    """Generate self-intersecting (bowtie) and other invalid polygons."""
+    rng = np.random.default_rng(seed)
+    geoms = []
+
+    # Bowtie/figure-8 polygons (self-intersecting)
+    for i in range(count // 2):
+        x_off = rng.uniform(-80, -70)
+        y_off = rng.uniform(35, 45)
+        size = rng.uniform(0.5, 2.0)
+        # Bowtie: two triangles sharing a vertex
+        coords = [
+            (x_off, y_off),  # left triangle
+            (x_off - size, y_off + size),
+            (x_off, y_off + size),
+            (x_off + size, y_off),  # right triangle
+            (x_off + size, y_off + size),
+            (x_off, y_off + size),
+            (x_off, y_off),
+        ]
+        geom = shapely.geometry.Polygon(coords)
+        burn_val = rng.random()
+        geoms.append((geom.wkb, float(burn_val)))
+
+    # Polygons with duplicate consecutive rings (invalid)
+    for i in range(count // 4):
+        x_off = rng.uniform(-120, -100)
+        y_off = rng.uniform(30, 45)
+        size = rng.uniform(0.3, 1.0)
+        box = shapely.geometry.box(x_off, y_off, x_off + size, y_off + size)
+        burn_val = rng.random()
+        geoms.append((box.wkb, float(burn_val)))
+
+    # Rings not closed (invalid) — manually crafted
+    for i in range(count // 4):
+        x_off = rng.uniform(-100, -80)
+        y_off = rng.uniform(35, 50)
+        size = rng.uniform(0.4, 1.5)
+        # Ring that doesn't close (missing final point == first)
+        coords = [
+            (x_off, y_off),
+            (x_off + size, y_off),
+            (x_off + size, y_off + size),
+            (x_off, y_off + size),
+            # Missing closure back to (x_off, y_off)
+        ]
+        try:
+            # This will likely be coerced to closed by shapely
+            geom = shapely.geometry.Polygon(coords)
+            burn_val = rng.random()
+            geoms.append((geom.wkb, float(burn_val)))
+        except Exception:
+            pass
+
+    return geoms
+
+
+def _gen_antimeridian_geometries(seed: int, count: int = 16) -> list:
+    """Generate geometries crossing the antimeridian (±180° longitude)."""
+    rng = np.random.default_rng(seed)
+    geoms = []
+
+    # Polygons spanning ±180° (e.g., -170 to +170 = 20° wide crossing antimeridian)
+    for i in range(count // 2):
+        lon_start = rng.uniform(170, 179)  # Start near 180
+        lat = rng.uniform(-60, 60)
+        width = rng.uniform(15, 30)  # Will span across ±180
+        height = rng.uniform(5, 20)
+
+        # Polygon from +170 to +190 (wraps around ±180)
+        coords = [
+            (lon_start, lat),
+            (lon_start + width, lat),
+            (lon_start + width, lat + height),
+            (lon_start, lat + height),
+            (lon_start, lat),
+        ]
+        geom = shapely.geometry.Polygon(coords)
+        burn_val = rng.random()
+        geoms.append((geom.wkb, float(burn_val)))
+
+    # LineStrings crossing antimeridian
+    for i in range(count // 2):
+        lon_start = rng.uniform(175, 180)
+        lat_start = rng.uniform(-60, 60)
+        lat_end = rng.uniform(-60, 60)
+
+        coords = [
+            (lon_start, lat_start),
+            (lon_start + 20, lat_end),
+        ]
+        geom = shapely.geometry.LineString(coords)
+        burn_val = rng.random()
+        geoms.append((geom.wkb, float(burn_val)))
+
+    return geoms
+
+
+def _gen_dense_vertices_geometries(seed: int, count: int = 16) -> list:
+    """Generate polygons/lines with dense, near-collinear, or duplicate vertices."""
+    rng = np.random.default_rng(seed)
+    geoms = []
+
+    # Polygons with many near-collinear points
+    for i in range(count // 2):
+        x_off = rng.uniform(-75, -70)
+        y_off = rng.uniform(40, 45)
+        width = rng.uniform(0.5, 2.0)
+        height = rng.uniform(0.5, 2.0)
+
+        # Create a box and add many intermediate points along each edge
+        coords = [(x_off, y_off)]
+        # Right edge: many points
+        for t in np.linspace(0, 1, 30):
+            coords.append((x_off + width * t, y_off))
+        # Top edge
+        for t in np.linspace(0, 1, 30):
+            coords.append((x_off + width, y_off + height * t))
+        # Left edge
+        for t in np.linspace(0, 1, 30):
+            coords.append((x_off + width * (1 - t), y_off + height))
+        # Bottom edge
+        for t in np.linspace(0, 1, 30):
+            coords.append((x_off, y_off + height * (1 - t)))
+        coords.append(coords[0])  # Close
+
+        geom = shapely.geometry.Polygon(coords)
+        burn_val = rng.random()
+        geoms.append((geom.wkb, float(burn_val)))
+
+    # LineStrings with many intermediate points
+    for i in range(count // 2):
+        x_start = rng.uniform(-75, -70)
+        y_start = rng.uniform(40, 45)
+        x_end = rng.uniform(-75, -70)
+        y_end = rng.uniform(40, 45)
+
+        # Line with many interpolated points
+        coords = [(x_start, y_start)]
+        for t in np.linspace(0.01, 0.99, 100):
+            x = x_start + t * (x_end - x_start)
+            y = y_start + t * (y_end - y_start)
+            # Add small random noise so points aren't exactly collinear
+            x += rng.normal(0, 1e-6)
+            y += rng.normal(0, 1e-6)
+            coords.append((x, y))
+        coords.append((x_end, y_end))
+
+        geom = shapely.geometry.LineString(coords)
+        burn_val = rng.random()
+        geoms.append((geom.wkb, float(burn_val)))
+
+    return geoms
+
+
+def _gen_overlapping_polygons(seed: int, count: int = 16) -> list:
+    """Generate overlapping polygon groups for coverage validity testing."""
+    rng = np.random.default_rng(seed)
+    geoms = []
+
+    # Create partially overlapping tiles that together form an invalid coverage
+    for i in range(count):
+        x_off = rng.uniform(-75, -70)
+        y_off = rng.uniform(40, 45)
+        size = rng.uniform(0.3, 0.8)
+
+        # Slight overlap or gap with neighbors
+        overlap_or_gap = rng.uniform(-0.1, 0.1)
+
+        box = shapely.geometry.box(
+            x_off, y_off, x_off + size + overlap_or_gap, y_off + size
+        )
+        burn_val = rng.random()
+        geoms.append((box.wkb, float(burn_val)))
+
+    return geoms
+
+
 # Geometry is derived from the FIRST size-sweep tile of each distinct CRS, so the
 # geometry corpus stays cheap (one set per CRS) yet covers every projection the
 # tile sweep uses. Each set's geometry is in-extent for its source tile; z-points
 # sample that tile's band 1. The representative manifest provenance is the first
 # size-sweep tile. Deterministic: the geometry seed is derived from the corpus
 # seed + the tile cellid, so re-running gen-data reproduces byte-identical WKB.
+#
+# Six geometry sets are generated:
+#   - srid_4326, srid_27700, ... (one per distinct CRS in the corpus) — standard
+#     boxes/points/zpoints for raster geometry aggregators.
+#   - st_validity, st_antimeridian, st_cleaning, st_coverage — ST function family
+#     geometry sets (invalid, antimeridian-crossing, dense-vertex, overlapping).
 def _write_geometry_corpus(out_dir, corpus: m.Corpus, seed: int) -> m.GeometryCorpus:
     out_dir = Path(out_dir)
     sets: dict = {}
@@ -358,6 +542,51 @@ def _write_geometry_corpus(out_dir, corpus: m.Corpus, seed: int) -> m.GeometryCo
         sets[f"srid_{te.srid}"] = gset
         if rep is None:
             rep = te
+
+    # Generate ST function family geometry sets (WGS84 basis, SRID 4326).
+    # Deterministic seeds derived from corpus seed.
+    ref_tile = rep.path if rep else ""
+
+    # st_validity: invalid geometries (bowties, unclosed rings)
+    validity_geoms = _gen_invalid_geometries(seed + 1001, count=16)
+    sets["st_validity"] = m.GeometrySet(
+        srid=4326,
+        source_tile=ref_tile,
+        boxes=validity_geoms,
+        points=[],
+        zpoints=[],
+    )
+
+    # st_antimeridian: geometries crossing ±180° longitude
+    antimerid_geoms = _gen_antimeridian_geometries(seed + 1002, count=16)
+    sets["st_antimeridian"] = m.GeometrySet(
+        srid=4326,
+        source_tile=ref_tile,
+        boxes=antimerid_geoms,
+        points=[],
+        zpoints=[],
+    )
+
+    # st_cleaning: dense vertices for simplify/reduce/node/snap
+    cleaning_geoms = _gen_dense_vertices_geometries(seed + 1003, count=16)
+    sets["st_cleaning"] = m.GeometrySet(
+        srid=4326,
+        source_tile=ref_tile,
+        boxes=cleaning_geoms,
+        points=[],
+        zpoints=[],
+    )
+
+    # st_coverage: overlapping polygons for coverage validity
+    coverage_geoms = _gen_overlapping_polygons(seed + 1004, count=16)
+    sets["st_coverage"] = m.GeometrySet(
+        srid=4326,
+        source_tile=ref_tile,
+        boxes=coverage_geoms,
+        points=[],
+        zpoints=[],
+    )
+
     gc = m.GeometryCorpus(
         seed=seed,
         srid=(rep.srid if rep else 0),

--- a/python/geobrix/src/databricks/labs/gbx/bench/runner.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/runner.py
@@ -1936,9 +1936,14 @@ def run_spark_path(  # noqa: C901
 
         _prx_reg.register(spark, only=[f.sql_name for f in _udtf_fns])
 
-    # geometry_scalar / geometry_aggregate ST fns AND geometry-input UDTFs call
-    # registered gbx_st_* SQL UDFs/UDTFs (pyvx); register them in this session or
-    # every col_fn expr / LATERAL call fails with UNRESOLVED_ROUTINE.
+    # geometry_scalar / geometry_aggregate fns AND geometry-input UDTFs call
+    # registered gbx_ SQL UDFs/UDTFs; register them in this session or every
+    # col_fn expr / LATERAL call fails with UNRESOLVED_ROUTINE. Route by OWNING
+    # TIER, not input_kind: input_kind=="geometry_aggregate" spans BOTH tiers --
+    # the raster aggregators (gbx_rst_rasterize_agg / gridfrompoints / dtmfromgeoms)
+    # are pyrx, while the vector geometry fns (gbx_st_*) and pmtiles/quadbin
+    # aggregators are pyvx. Sending an rst_ name to the pyvx registrar fails its
+    # name validation.
     _geom_fns = [
         f
         for f in fnspecs
@@ -1949,10 +1954,16 @@ def run_spark_path(  # noqa: C901
             or (getattr(f, "udtf", False) and getattr(f, "geometry_set", None))
         )
     ]
-    if _geom_fns:
+    _geom_pyrx = [f for f in _geom_fns if f.sql_name.startswith("gbx_rst_")]
+    _geom_pyvx = [f for f in _geom_fns if not f.sql_name.startswith("gbx_rst_")]
+    if _geom_pyrx:
+        from databricks.labs.gbx.pyrx import functions as _prx_reg
+
+        _prx_reg.register(spark, only=[f.sql_name for f in _geom_pyrx])
+    if _geom_pyvx:
         from databricks.labs.gbx.pyvx import functions as _pyvx_reg
 
-        _pyvx_reg.register(spark, only=[f.sql_name for f in _geom_fns])
+        _pyvx_reg.register(spark, only=[f.sql_name for f in _geom_pyvx])
 
     # Spark warm-up: one throwaway job so JVM/Spark spin-up isn't charged to the first
     # timed cell (delegated to _spark_path_warmup).

--- a/python/geobrix/src/databricks/labs/gbx/bench/runner.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/runner.py
@@ -948,10 +948,21 @@ def _run_aggregate(
         one = group_df.withColumn("key", F.lit(0))
         collected = one.groupBy("key").agg(_agg_col(one).alias("out")).collect()
         if collected:
-            tile = collected[0]["out"]
-            raster = tile["raster"] if tile is not None else None
+            out_val = collected[0]["out"]
+            # Tile-producing aggregators return a struct with a "raster" field;
+            # scalar/geometry aggregators (e.g. coverage validity) return a bool
+            # or WKB bytes -- don't assume a tile struct.
+            raster = None
+            if out_val is not None:
+                try:
+                    raster = out_val["raster"]
+                except (TypeError, KeyError, ValueError):
+                    raster = None
             if raster:
                 fingerprint = _fingerprint_for(fs, bytes(raster))
+            elif fs.fingerprint and isinstance(out_val, (bytes, bytearray)):
+                # WKB-returning aggregator (e.g. coverageinvalidedges).
+                fingerprint = _fingerprint_for(fs, bytes(out_val))
     except Exception as e:  # noqa: BLE001
         return [
             _agg_result_row(fs, run_id, pool, n, env, None, "", "error", str(e)[:300])

--- a/python/geobrix/src/databricks/labs/gbx/bench/runner.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/runner.py
@@ -1905,6 +1905,19 @@ def run_spark_path(  # noqa: C901
 
         _prx_reg.register(spark, only=[f.sql_name for f in _udtf_fns])
 
+    # geometry_scalar ST fns call registered gbx_st_* SQL UDFs (pyvx); register them
+    # in this session or every col_fn expr fails with UNRESOLVED_ROUTINE.
+    _geom_scalar_fns = [
+        f
+        for f in fnspecs
+        if getattr(f, "input_kind", "tile") == "geometry_scalar"
+        and "spark-path" in f.modes
+    ]
+    if _geom_scalar_fns:
+        from databricks.labs.gbx.pyvx import functions as _pyvx_reg
+
+        _pyvx_reg.register(spark, only=[f.sql_name for f in _geom_scalar_fns])
+
     # Spark warm-up: one throwaway job so JVM/Spark spin-up isn't charged to the first
     # timed cell (delegated to _spark_path_warmup).
     _spark_path_warmup(spark, fnspecs, pool, df_all, _input_col)

--- a/python/geobrix/src/databricks/labs/gbx/bench/runner.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/runner.py
@@ -142,15 +142,26 @@ def _load_geometry_corpus(corpus_root):
     return m.GeometryCorpus.read(p)
 
 
-def _geometry_set_for(geom_corpus, te):
-    """The GeometrySet for a tile: by source_tile path, else by matching srid.
+def _geometry_set_for(geom_corpus, te, geometry_set_override=None):
+    """The GeometrySet for a tile: by explicit override, source_tile, or srid.
 
-    Geometry is generated per distinct CRS from a representative tile, so a tile
-    whose own path is not a geometry source still gets the in-extent set for its
-    srid (same projection, so the bounds-derived geometry is in-extent).
+    When geometry_set_override is set, use geom_corpus.sets[geometry_set_override] if
+    it exists. Otherwise, geometry is generated per distinct CRS from a representative
+    tile, so a tile whose own path is not a geometry source still gets the in-extent
+    set for its srid (same projection, so the bounds-derived geometry is in-extent).
     """
     if geom_corpus is None:
         return None
+    # Honor explicit per-function geometry set override.
+    if geometry_set_override is not None:
+        if geometry_set_override in geom_corpus.sets:
+            return geom_corpus.sets[geometry_set_override]
+        else:
+            raise ValueError(
+                f"geometry_set '{geometry_set_override}' not found in corpus. "
+                f"Available: {list(geom_corpus.sets.keys())}"
+            )
+    # Default: match by source_tile path, else by srid.
     for gset in geom_corpus.sets.values():
         if gset.source_tile == te.path:
             return gset
@@ -360,7 +371,11 @@ def run_pure_core(
                 else None
             )
             geom = (
-                _geometry_set_for(geom_corpus, te) if input_kind == "geometry" else None
+                _geometry_set_for(
+                    geom_corpus, te, getattr(fs, "geometry_set", None)
+                )
+                if input_kind == "geometry"
+                else None
             )
 
             try:
@@ -603,15 +618,14 @@ def _geometry_aggregate_df(spark, root, corpus, fs):
     geom_corpus = _load_geometry_corpus(root)
     if geom_corpus is None:
         raise RuntimeError("geometry.json absent; cannot run geometry aggregator")
-    # The representative source tile (first row_pool tile) supplies extent + geom.
-    src_rel = corpus.row_pool.tiles[0].path
-    gset = None
-    for g in geom_corpus.sets.values():
-        if g.source_tile == src_rel:
-            gset = g
-            break
+    # Honor explicit geometry_set if set, else fall back to source_tile/srid lookup.
+    gset = _geometry_set_for(geom_corpus, corpus.row_pool.tiles[0], getattr(fs, "geometry_set", None))
     if gset is None:
-        gset = next(iter(geom_corpus.sets.values()))
+        raise RuntimeError(
+            f"Could not find geometry set for {fs.name} with geometry_set={getattr(fs, 'geometry_set', None)}"
+        )
+    # The representative source tile supplies extent.
+    src_rel = gset.source_tile
     with rasterio.open(root / src_rel) as ds:
         left, bottom, right, top = ds.bounds
         epsg = ds.crs.to_epsg() if ds.crs is not None else None
@@ -628,7 +642,7 @@ def _geometry_aggregate_df(spark, root, corpus, fs):
         pairs = [(bytes(wkb), 0.0) for wkb in gset.zpoints]
     elif fs.name == "rst_gridfrompoints_agg":
         pairs = [(bytes(wkb), float(v)) for wkb, v in gset.points]
-    else:  # rst_rasterize_agg
+    else:  # rst_rasterize_agg or st_coverage*
         pairs = [(bytes(wkb), float(v)) for wkb, v in gset.boxes]
     schema = StructType(
         [
@@ -1749,15 +1763,24 @@ def run_spark_path(  # noqa: C901
         return F.array(*elems)
 
     def _input_col(fn: str, kind: str, df=None):
-        """The column fed to col_fn: an array literal for tile_array, else the tile.
+        """The column fed to col_fn: array literal for tile_array, geom for geometry_scalar, else tile.
 
-        ``df`` selects which DataFrame's ``tile`` column to reference -- the measured
+        ``df`` selects which DataFrame's column to reference -- the measured
         pass uses df_all, the warm-up pass uses the one-row-per-partition warm DF (a
         cross-DataFrame column ref would fail analysis, so each pass passes its own df).
-        The tile_array literal is DataFrame-independent.
+        The tile_array literal is DataFrame-independent; geometry_scalar routes to a
+        geometry DataFrame (passed separately below, not via df).
         """
-        _d = df_all if df is None else df
-        return _synth_array_col(fn) if kind == "tile_array" else _d["tile"]
+        if kind == "tile_array":
+            return _synth_array_col(fn)
+        elif kind == "geometry_scalar":
+            # Geometry column; df is the geometry DataFrame for this fn's set.
+            # If df is None, fall back to df_all["geom"] (shouldn't happen in normal flow).
+            _d = df if df is not None else df_all
+            return _d["geom"] if "geom" in _d.columns else _d["tile"]
+        else:
+            _d = df_all if df is None else df
+            return _d["tile"]
 
     # Warm-up DF: exactly one tile row per partition of df_all (mapPartitions -> take 1),
     # so a warm-up pass exercises EVERY executor slot's Python worker / UDF once without
@@ -1799,6 +1822,54 @@ def run_spark_path(  # noqa: C901
             df_gb.count()
             warm_df_gb = _one_row_per_partition(spark, df_gb).cache()
             warm_df_gb.count()
+
+    # Geometry DataFrames for scalar-geometry ST functions (e.g., st_makevalid, st_split).
+    # Build one per distinct geometry_set used by the batch's geometry_scalar fns,
+    # following the same pattern as df_gb/warm_df_gb: replicate to max_rows rows,
+    # repartition, cache, and warm.
+    geom_corpus = _load_geometry_corpus(root)
+    _geometry_dfs = {}  # Maps geometry_set -> (df, warm_df)
+    _want_geometry_sets = set()
+    if geom_corpus is not None:
+        for f in fnspecs:
+            if getattr(f, "input_kind", "tile") == "geometry_scalar":
+                gset_name = getattr(f, "geometry_set", None)
+                if gset_name is not None:
+                    _want_geometry_sets.add(gset_name)
+
+    if _want_geometry_sets and not explain_only:
+        from pyspark.sql.types import BinaryType, StructField, StructType
+
+        for gset_name in _want_geometry_sets:
+            if gset_name not in geom_corpus.sets:
+                print(
+                    f"[bench] geometry_set '{gset_name}' not found in corpus; "
+                    f"skipping this set of functions"
+                )
+                continue
+            gset = geom_corpus.sets[gset_name]
+            # Build (geom BINARY) pairs: extract WKB from the geometry set.
+            # For scalar geometry functions, use boxes (2D polygon geometries).
+            # If boxes is empty, fall back to points or zpoints.
+            if gset.boxes:
+                geoms = [bytes(wkb) for wkb, _ in gset.boxes]
+            elif gset.points:
+                geoms = [bytes(wkb) for wkb, _ in gset.points]
+            elif gset.zpoints:
+                geoms = [bytes(wkb) for wkb in gset.zpoints]
+            else:
+                print(f"[bench] geometry_set '{gset_name}' has no geometries; skipping")
+                continue
+            # Cycle geometries to fill max_rows rows.
+            geom_pairs = [(geoms[i % len(geoms)],) for i in range(max_rows)]
+            schema = StructType([StructField("geom", BinaryType(), False)])
+            df_geom = spark.createDataFrame(geom_pairs, schema=schema)
+            df_geom = df_geom.repartition(_nparts, F.rand()).cache()
+            df_geom.count()  # materialize the cache
+            warm_df_geom = _one_row_per_partition(spark, df_geom).cache()
+            warm_df_geom.count()
+            _geometry_dfs[gset_name] = (df_geom, warm_df_geom)
+            print(f"[bench] loaded geometry_set '{gset_name}' with {len(geoms)} unique geometries")
 
     # --explain-only: build each fn's spark-path DataFrame and PRINT its physical plan,
     # no timing / no Delta write (delegated to _explain_spark_path).
@@ -1867,17 +1938,25 @@ def run_spark_path(  # noqa: C901
         if "spark-path" not in fs.modes:
             continue
         _sp_leg_i += 1
-        # Route gb_tile fns (BNG raster->grid / tessellate, which reproject to
-        # EPSG:27700 and drop out-of-GB pixels) to the dedicated GB tile DF so
-        # they bench REAL cells.  Every other fn uses the ordinary NYC row pool DF.
-        _fn_df = (
-            df_gb if (getattr(fs, "gb_tile", False) and df_gb is not None) else df_all
-        )
-        _fn_warm_df = (
-            warm_df_gb
-            if (getattr(fs, "gb_tile", False) and warm_df_gb is not None)
-            else _warm_df
-        )
+        # Route based on input_kind and attributes:
+        # - gb_tile fns: use GB tile DF (EPSG:27700 cells)
+        # - geometry_scalar fns: use their geometry set DF
+        # - others: use the ordinary NYC tile row pool DF
+        _input_kind = getattr(fs, "input_kind", "tile")
+        if _input_kind == "geometry_scalar":
+            # Geometry scalar function: route to its geometry set's DF
+            gset_name = getattr(fs, "geometry_set", None)
+            if gset_name and gset_name in _geometry_dfs:
+                _fn_df, _fn_warm_df = _geometry_dfs[gset_name]
+            else:
+                print(f"[bench] {fs.name}: geometry_set '{gset_name}' not available, skipping")
+                continue
+        elif getattr(fs, "gb_tile", False) and df_gb is not None:
+            _fn_df = df_gb
+            _fn_warm_df = warm_df_gb
+        else:
+            _fn_df = df_all
+            _fn_warm_df = _warm_df
         _mark = len(out)
         if getattr(fs, "input_kind", "tile") in _agg_kinds:
             out += _run_aggregate(

--- a/python/geobrix/src/databricks/labs/gbx/bench/runner.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/runner.py
@@ -1905,18 +1905,19 @@ def run_spark_path(  # noqa: C901
 
         _prx_reg.register(spark, only=[f.sql_name for f in _udtf_fns])
 
-    # geometry_scalar ST fns call registered gbx_st_* SQL UDFs (pyvx); register them
-    # in this session or every col_fn expr fails with UNRESOLVED_ROUTINE.
-    _geom_scalar_fns = [
+    # geometry_scalar and geometry_aggregate ST fns call registered gbx_st_* SQL UDFs
+    # (pyvx); register them in this session or every col_fn expr fails with
+    # UNRESOLVED_ROUTINE.
+    _geom_fns = [
         f
         for f in fnspecs
-        if getattr(f, "input_kind", "tile") == "geometry_scalar"
+        if getattr(f, "input_kind", "tile") in ("geometry_scalar", "geometry_aggregate")
         and "spark-path" in f.modes
     ]
-    if _geom_scalar_fns:
+    if _geom_fns:
         from databricks.labs.gbx.pyvx import functions as _pyvx_reg
 
-        _pyvx_reg.register(spark, only=[f.sql_name for f in _geom_scalar_fns])
+        _pyvx_reg.register(spark, only=[f.sql_name for f in _geom_fns])
 
     # Spark warm-up: one throwaway job so JVM/Spark spin-up isn't charged to the first
     # timed cell (delegated to _spark_path_warmup).

--- a/python/geobrix/src/databricks/labs/gbx/bench/runner.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/runner.py
@@ -371,9 +371,7 @@ def run_pure_core(
                 else None
             )
             geom = (
-                _geometry_set_for(
-                    geom_corpus, te, getattr(fs, "geometry_set", None)
-                )
+                _geometry_set_for(geom_corpus, te, getattr(fs, "geometry_set", None))
                 if input_kind == "geometry"
                 else None
             )
@@ -619,7 +617,9 @@ def _geometry_aggregate_df(spark, root, corpus, fs):
     if geom_corpus is None:
         raise RuntimeError("geometry.json absent; cannot run geometry aggregator")
     # Honor explicit geometry_set if set, else fall back to source_tile/srid lookup.
-    gset = _geometry_set_for(geom_corpus, corpus.row_pool.tiles[0], getattr(fs, "geometry_set", None))
+    gset = _geometry_set_for(
+        geom_corpus, corpus.row_pool.tiles[0], getattr(fs, "geometry_set", None)
+    )
     if gset is None:
         raise RuntimeError(
             f"Could not find geometry set for {fs.name} with geometry_set={getattr(fs, 'geometry_set', None)}"
@@ -860,7 +860,7 @@ def _build_agg_group_df(spark, root, corpus, fs, kind):
     return group_df, False, extent
 
 
-def _run_aggregate(
+def _run_aggregate(  # noqa: C901
     spark,
     root,
     corpus,
@@ -1141,6 +1141,8 @@ def _sql_literal(v) -> str:
     (resolution / tile_width / tile_height / overlap / min_z / max_z), but keep the
     string branch defensive so a future string-arg UDTF still renders correctly.
     """
+    if v is None:
+        return "NULL"
     if isinstance(v, bool):
         return "true" if v else "false"
     if isinstance(v, (int, float)):
@@ -1161,9 +1163,13 @@ def _udtf_lateral_sql(view: str, fs) -> str:
     (and written to noop for timing), not short-circuited.
     """
     scalar_args = "".join(", " + _sql_literal(v) for v in fs.args.values())
+    # Grid UDTFs (rastertogrid* / tessellate) take the raster tile struct as their
+    # first arg; geometry UDTFs (st_asmvt_pyramid) take a WKB geometry column from
+    # the geometry corpus (routed by geometry_set). Same LATERAL shape either way.
+    _first = "d.geom" if getattr(fs, "geometry_set", None) else "d.tile"
     return (
         f"SELECT t.* FROM {view} AS d, "
-        f"LATERAL {fs.sql_name}(d.tile{scalar_args}) AS t"
+        f"LATERAL {fs.sql_name}({_first}{scalar_args}) AS t"
     )
 
 
@@ -1843,7 +1849,12 @@ def run_spark_path(  # noqa: C901
     _want_geometry_sets = set()
     if geom_corpus is not None:
         for f in fnspecs:
-            if getattr(f, "input_kind", "tile") == "geometry_scalar":
+            # Scalar-geometry fns AND geometry-input UDTFs (udtf + geometry_set,
+            # e.g. st_asmvt_pyramid) both need a WKB geom view built for their set.
+            _is_geom_udtf = getattr(f, "udtf", False) and getattr(
+                f, "geometry_set", None
+            )
+            if getattr(f, "input_kind", "tile") == "geometry_scalar" or _is_geom_udtf:
                 gset_name = getattr(f, "geometry_set", None)
                 if gset_name is not None:
                     _want_geometry_sets.add(gset_name)
@@ -1880,7 +1891,9 @@ def run_spark_path(  # noqa: C901
             warm_df_geom = _one_row_per_partition(spark, df_geom).cache()
             warm_df_geom.count()
             _geometry_dfs[gset_name] = (df_geom, warm_df_geom)
-            print(f"[bench] loaded geometry_set '{gset_name}' with {len(geoms)} unique geometries")
+            print(
+                f"[bench] loaded geometry_set '{gset_name}' with {len(geoms)} unique geometries"
+            )
 
     # --explain-only: build each fn's spark-path DataFrame and PRINT its physical plan,
     # no timing / no Delta write (delegated to _explain_spark_path).
@@ -1908,22 +1921,33 @@ def run_spark_path(  # noqa: C901
     # UDTFs needed by this run's udtf fns (idempotent; last registration wins) so the
     # LATERAL branch below can call them. The scalar col_fn path never needs this
     # (its UDFs are module-level singletons), so register only when a udtf fn is present.
+    # Grid UDTFs (rastertogrid* / tessellate) are pyrx; geometry-input UDTFs
+    # (st_asmvt_pyramid, marked by geometry_set) are pyvx and register with the
+    # geometry fns below -- so exclude them here or the pyrx registrar can't find them.
     _udtf_fns = [
-        f for f in fnspecs if getattr(f, "udtf", False) and "spark-path" in f.modes
+        f
+        for f in fnspecs
+        if getattr(f, "udtf", False)
+        and "spark-path" in f.modes
+        and not getattr(f, "geometry_set", None)
     ]
     if _udtf_fns:
         from databricks.labs.gbx.pyrx import functions as _prx_reg
 
         _prx_reg.register(spark, only=[f.sql_name for f in _udtf_fns])
 
-    # geometry_scalar and geometry_aggregate ST fns call registered gbx_st_* SQL UDFs
-    # (pyvx); register them in this session or every col_fn expr fails with
-    # UNRESOLVED_ROUTINE.
+    # geometry_scalar / geometry_aggregate ST fns AND geometry-input UDTFs call
+    # registered gbx_st_* SQL UDFs/UDTFs (pyvx); register them in this session or
+    # every col_fn expr / LATERAL call fails with UNRESOLVED_ROUTINE.
     _geom_fns = [
         f
         for f in fnspecs
-        if getattr(f, "input_kind", "tile") in ("geometry_scalar", "geometry_aggregate")
-        and "spark-path" in f.modes
+        if "spark-path" in f.modes
+        and (
+            getattr(f, "input_kind", "tile")
+            in ("geometry_scalar", "geometry_aggregate")
+            or (getattr(f, "udtf", False) and getattr(f, "geometry_set", None))
+        )
     ]
     if _geom_fns:
         from databricks.labs.gbx.pyvx import functions as _pyvx_reg
@@ -1968,13 +1992,17 @@ def run_spark_path(  # noqa: C901
         # - geometry_scalar fns: use their geometry set DF
         # - others: use the ordinary NYC tile row pool DF
         _input_kind = getattr(fs, "input_kind", "tile")
-        if _input_kind == "geometry_scalar":
-            # Geometry scalar function: route to its geometry set's DF
+        _is_geom_udtf = getattr(fs, "udtf", False) and getattr(fs, "geometry_set", None)
+        if _input_kind == "geometry_scalar" or _is_geom_udtf:
+            # Scalar-geometry fn OR geometry-input UDTF: route to its geometry set's
+            # DF (a WKB `geom` column view the scalar col_fn / LATERAL join reads).
             gset_name = getattr(fs, "geometry_set", None)
             if gset_name and gset_name in _geometry_dfs:
                 _fn_df, _fn_warm_df = _geometry_dfs[gset_name]
             else:
-                print(f"[bench] {fs.name}: geometry_set '{gset_name}' not available, skipping")
+                print(
+                    f"[bench] {fs.name}: geometry_set '{gset_name}' not available, skipping"
+                )
                 continue
         elif getattr(fs, "gb_tile", False) and df_gb is not None:
             _fn_df = df_gb

--- a/python/geobrix/src/databricks/labs/gbx/bench/spec.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/spec.py
@@ -3262,18 +3262,23 @@ REGISTRY: Dict[str, FnSpec] = {
         geometry_set="st_cleaning",
         sources=_PYVX_CLEANING_LIGHT,
     ),
-    # --- Coverage Functions (Light-Only) ---
+    # --- Coverage Functions (Light-Only, grouped-aggregates) ---
+    # Coverage validation aggregates: consume a GROUP of polygons and validate
+    # the coverage topology. Input routes via geometry_aggregate (geom_wkb, value)
+    # pairs grouped as one batch. Coverage functions use only the geom column.
     "st_coverageisvalid": FnSpec(
         "st_coverageisvalid",
         "gbx_st_coverageisvalid",
         "vector",
         ("spark-path",),
         {},
-        col_fn=lambda col, a: pyvx.st_coverageisvalid(col),
-        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        # col_fn receives (geom_col, value_col, extent_tuple, args) from the
+        # geometry_aggregate harness; coverage uses only the geom column.
+        col_fn=lambda g, v, ext, a: pyvx.st_coverageisvalid(g),
+        core_fn=lambda t, a: t,  # spark-path-only; no pure-core analogue
         core=False,
         fingerprint=False,  # Timing-only; boolean result
-        input_kind="geometry_scalar",
+        input_kind="geometry_aggregate",
         geometry_set="st_coverage",
         sources=_PYVX_COVERAGE_LIGHT,
     ),
@@ -3283,11 +3288,13 @@ REGISTRY: Dict[str, FnSpec] = {
         "vector",
         ("spark-path",),
         {},
-        col_fn=lambda col, a: pyvx.st_coverageinvalidedges(col),
-        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        # col_fn receives (geom_col, value_col, extent_tuple, args) from the
+        # geometry_aggregate harness; coverage uses only the geom column.
+        col_fn=lambda g, v, ext, a: pyvx.st_coverageinvalidedges(g),
+        core_fn=lambda t, a: t,  # spark-path-only; no pure-core analogue
         core=False,
         fingerprint=True,
-        input_kind="geometry_scalar",
+        input_kind="geometry_aggregate",
         geometry_set="st_coverage",
         sources=_PYVX_COVERAGE_LIGHT,
     ),

--- a/python/geobrix/src/databricks/labs/gbx/bench/spec.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/spec.py
@@ -3131,8 +3131,11 @@ REGISTRY: Dict[str, FnSpec] = {
         "vector",
         ("spark-path",),
         {},  # blade built inline in col_fn (F.lit) so args stays JSON-serializable
+        # Blade must be a LINE to split a polygon (shapely.ops.split rejects a
+        # polygon blade). Use the antimeridian meridian at x=180; the corpus
+        # crossers are represented in 0..360 lon, so this line bisects them.
         col_fn=lambda col, a: pyvx.st_split(
-            col, F.lit(shapely.geometry.box(-180, -90, -179.9, 90).wkb)
+            col, F.lit(shapely.geometry.LineString([(180, -95), (180, 95)]).wkb)
         ),
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,

--- a/python/geobrix/src/databricks/labs/gbx/bench/spec.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/spec.py
@@ -292,6 +292,12 @@ class FnSpec:
     # from the pixel-reading allowlist below. Ignored for tile-returning ops
     # (their disposition is sampled from the output tile at run time).
     virtual_disposition: Optional[str] = None
+    # Optional geometry set name for functions that operate on scalar geometry
+    # input (VectorX ST functions). When set, the bench uses geom_corpus.sets[geometry_set]
+    # for that function's geometry input. When None, uses the default srid/source_tile
+    # matching behavior (so raster geometry aggregators that reuse srid_4326/srid_27700
+    # are UNAFFECTED).
+    geometry_set: Optional[str] = None
 
 
 _BOTH = ("pure-core", "spark-path")
@@ -2976,13 +2982,14 @@ REGISTRY: Dict[str, FnSpec] = {
         "gbx_st_asmvt",
         "vector",
         ("spark-path",),
-        {},
-        col_fn=lambda col, a: pyvx.st_asmvt(col, F.lit(None), F.lit(None)),  # Placeholder attrs/layer
+        {"extent": 4096, "layer_name": "features"},
+        col_fn=lambda col, a: pyvx.st_asmvt(col, F.lit(None), F.lit(a["layer_name"])),
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
         fingerprint_kind="vector",
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="srid_4326",
         sources=_PYVX_MVT_LIGHT + (_VECTORX + "ST_AsMvt.scala",),
     ),
     "st_legacyaswkb": FnSpec(
@@ -2995,7 +3002,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="srid_4326",
         sources=(_PYVX + "_legacy.py", "src/main/scala/com/databricks/labs/gbx/vectorx/jts/legacy/expressions/ST_LegacyAsWKB.scala"),
     ),
     "st_triangulate": FnSpec(
@@ -3059,13 +3067,14 @@ REGISTRY: Dict[str, FnSpec] = {
         "st_crs",
         "gbx_st_crs",
         "vector",
-        ("pure-core",),  # Header accessor, no spark-path needed
+        ("spark-path",),  # Spark-path only; lightweight accessor
         {},
-        core_fn=lambda ds, a: None,  # Timing-only placeholder
-        col_fn=lambda col, a: None,  # Placeholder; pure-core only
-        core=True,
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        col_fn=lambda col, a: pyvx.st_crs(col),
+        core=False,
         fingerprint=False,  # Timing-only
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="srid_4326",
         virtual_disposition="deferred",  # Header-only, no pixel read
         sources=_PYVX_CRS_LIGHT + (_VECTORX + "ST_Crs.scala",),
     ),
@@ -3073,13 +3082,14 @@ REGISTRY: Dict[str, FnSpec] = {
         "st_setcrs",
         "gbx_st_setcrs",
         "vector",
-        ("pure-core", "spark-path"),
+        ("spark-path",),
         {"srid": 4326},  # Default WGS84
-        core_fn=lambda col, a: None,  # Placeholder for pure-core
+        core_fn=lambda col, a: None,  # Placeholder for spark-path only
         col_fn=lambda col, a: pyvx.st_setcrs(col, F.lit(a["srid"])),
-        core=True,
+        core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="srid_4326",
         virtual_disposition="deferred",  # Header edit only
         sources=_PYVX_CRS_LIGHT + (_VECTORX + "ST_SetCrs.scala",),
     ),
@@ -3087,15 +3097,16 @@ REGISTRY: Dict[str, FnSpec] = {
         "st_transformcrs",
         "gbx_st_transformcrs",
         "vector",
-        ("pure-core", "spark-path"),
+        ("spark-path",),
         {"source_crs": "EPSG:4326", "target_crs": "EPSG:3857"},
-        core_fn=lambda col, a: None,  # Placeholder for pure-core
+        core_fn=lambda col, a: None,  # Placeholder for spark-path only
         col_fn=lambda col, a: pyvx.st_transformcrs(
             col, F.lit(a["target_crs"]), F.lit(a["source_crs"])
         ),
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="srid_4326",
         virtual_disposition="materialized",  # Full WKB transform
         sources=_PYVX_CRS_LIGHT + (_VECTORX + "ST_TransformCrs.scala",),
     ),
@@ -3105,12 +3116,13 @@ REGISTRY: Dict[str, FnSpec] = {
         "gbx_st_shiftlongitude",
         "vector",
         ("spark-path",),
-        {"shift": 180},
+        {},
         col_fn=lambda col, a: pyvx.st_shiftlongitude(col),
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_antimeridian",
         sources=_PYVX_ANTIMERIDIAN_LIGHT,
     ),
     "st_split": FnSpec(
@@ -3118,12 +3130,15 @@ REGISTRY: Dict[str, FnSpec] = {
         "gbx_st_split",
         "vector",
         ("spark-path",),
-        {},
-        col_fn=lambda col, a: pyvx.st_split(col, F.lit(None)),  # Placeholder blade
+        {},  # blade built inline in col_fn (F.lit) so args stays JSON-serializable
+        col_fn=lambda col, a: pyvx.st_split(
+            col, F.lit(shapely.geometry.box(-180, -90, -179.9, 90).wkb)
+        ),
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_antimeridian",
         sources=_PYVX_ANTIMERIDIAN_LIGHT,
     ),
     "st_wrapx": FnSpec(
@@ -3138,7 +3153,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_antimeridian",
         sources=_PYVX_ANTIMERIDIAN_LIGHT,
     ),
     # --- Validity Functions (Light-Only) ---
@@ -3152,7 +3168,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=False,  # Timing-only; text output
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_validity",
         sources=_PYVX_VALIDITY_LIGHT,
     ),
     "st_makevalid": FnSpec(
@@ -3165,7 +3182,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_validity",
         sources=_PYVX_VALIDITY_LIGHT,
     ),
     # --- Cleaning Functions (Light-Only) ---
@@ -3179,7 +3197,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_cleaning",
         sources=_PYVX_CLEANING_LIGHT,
     ),
     "st_reduceprecision": FnSpec(
@@ -3192,7 +3211,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_cleaning",
         sources=_PYVX_CLEANING_LIGHT,
     ),
     "st_removerepeatedpoints": FnSpec(
@@ -3205,7 +3225,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_cleaning",
         sources=_PYVX_CLEANING_LIGHT,
     ),
     "st_simplifypreservetopology": FnSpec(
@@ -3218,7 +3239,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_cleaning",
         sources=_PYVX_CLEANING_LIGHT,
     ),
     "st_snap": FnSpec(
@@ -3233,7 +3255,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_cleaning",
         sources=_PYVX_CLEANING_LIGHT,
     ),
     # --- Coverage Functions (Light-Only) ---
@@ -3247,7 +3270,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=False,  # Timing-only; boolean result
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_coverage",
         sources=_PYVX_COVERAGE_LIGHT,
     ),
     "st_coverageinvalidedges": FnSpec(
@@ -3260,7 +3284,8 @@ REGISTRY: Dict[str, FnSpec] = {
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
-        input_kind="tile",
+        input_kind="geometry_scalar",
+        geometry_set="st_coverage",
         sources=_PYVX_COVERAGE_LIGHT,
     ),
 }

--- a/python/geobrix/src/databricks/labs/gbx/bench/spec.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/spec.py
@@ -22,6 +22,7 @@ import shapely.wkb
 from pyspark.sql import functions as F
 
 from databricks.labs.gbx.pyrx import functions as prx
+from databricks.labs.gbx.pyvx import functions as pyvx
 from databricks.labs.gbx.pyrx.core import accessors
 from databricks.labs.gbx.pyrx.core import agg as agg_core
 from databricks.labs.gbx.pyrx.core import analysis as analysis_core
@@ -380,6 +381,17 @@ _TESSELLATE_LIGHT = (_PYRX + "tessellate.py", _PYRX + "edit.py")
 # H3 rasterize aggregator (cellid,value rows -> one tile, pixel-centroid burn).
 # Light burn math + gridspec port live in core/cellraster.py.
 _CELLRASTER_LIGHT = (_PYRX + "cellraster.py",)
+
+# VectorX (pyvx/vectorx) source paths for light and heavy tiers.
+_PYVX = "python/geobrix/src/databricks/labs/gbx/pyvx/"
+_VECTORX = "src/main/scala/com/databricks/labs/gbx/vectorx/expressions/"
+# Light-only CRS, antimeridian, validity, cleaning, and coverage functions.
+_PYVX_CRS_LIGHT = (_PYVX + "_crs.py",)
+_PYVX_ANTIMERIDIAN_LIGHT = (_PYVX + "_antimeridian.py",)
+_PYVX_VALIDITY_LIGHT = (_PYVX + "_validity.py",)
+_PYVX_CLEANING_LIGHT = (_PYVX + "_cleaning.py",)
+_PYVX_COVERAGE_LIGHT = (_PYVX + "_coverage.py",)
+_PYVX_MVT_LIGHT = (_PYVX + "_mvt.py", _PYVX + "_serde.py")
 
 # --- rst_h3_rasterize_agg: fixed deterministic cell set + EXPLICIT grid --------
 # PARITY CONTRACT (must stay byte-for-byte in sync with the Scala BenchDispatch
@@ -2957,6 +2969,300 @@ REGISTRY: Dict[str, FnSpec] = {
         ),
         core=False,
     ),
+    # --- VectorX (pyvx/vectorx) functions ---
+    # Already-benched ST functions (MVT, TIN families).
+    "st_asmvt": FnSpec(
+        "st_asmvt",
+        "gbx_st_asmvt",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_asmvt(col, F.lit(None), F.lit(None)),  # Placeholder attrs/layer
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        fingerprint_kind="vector",
+        input_kind="tile",
+        sources=_PYVX_MVT_LIGHT + (_VECTORX + "ST_AsMvt.scala",),
+    ),
+    "st_legacyaswkb": FnSpec(
+        "st_legacyaswkb",
+        "gbx_st_legacyaswkb",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_legacyaswkb(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=(_PYVX + "_legacy.py", "src/main/scala/com/databricks/labs/gbx/vectorx/jts/legacy/expressions/ST_LegacyAsWKB.scala"),
+    ),
+    "st_triangulate": FnSpec(
+        "st_triangulate",
+        "gbx_st_triangulate",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_triangulate(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only (UDTF)
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=(_PYVX + "_tin.py", _VECTORX + "ST_Triangulate.scala"),
+    ),
+    "st_interpolateelevationgeom": FnSpec(
+        "st_interpolateelevationgeom",
+        "gbx_st_interpolateelevationgeom",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_interpolateelevationgeom(col, F.lit(None)),  # Placeholder points
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=(_PYVX + "_tin.py", _VECTORX + "ST_InterpolateElevationGeom.scala"),
+    ),
+    "st_interpolateelevationbbox": FnSpec(
+        "st_interpolateelevationbbox",
+        "gbx_st_interpolateelevationbbox",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_interpolateelevationbbox(col, F.lit(None)),  # Placeholder points
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=(_PYVX + "_tin.py", _VECTORX + "ST_InterpolateElevationBBox.scala"),
+    ),
+    # 16 new vector function benchmarks: 1 heavy+light (asmvt_pyramid), 15 light-only
+    # (CRS, antimeridian, validity, cleaning, coverage families).
+    "st_asmvt_pyramid": FnSpec(
+        "st_asmvt_pyramid",
+        "gbx_st_asmvt_pyramid",
+        "vector",
+        ("spark-path",),  # Spark-path only (UDTF); no pure-core
+        {"min_z": 0, "max_z": 14, "layer_name": "features"},
+        col_fn=lambda col, a: pyvx.st_asmvt_pyramid(
+            col, a["min_z"], a["max_z"], a["layer_name"]
+        ),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path-only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_MVT_LIGHT + (_VECTORX + "ST_AsMvtPyramid.scala",),
+    ),
+    # --- CRS Functions (Light-Only) ---
+    "st_crs": FnSpec(
+        "st_crs",
+        "gbx_st_crs",
+        "vector",
+        ("pure-core",),  # Header accessor, no spark-path needed
+        {},
+        core_fn=lambda ds, a: None,  # Timing-only placeholder
+        col_fn=lambda col, a: None,  # Placeholder; pure-core only
+        core=True,
+        fingerprint=False,  # Timing-only
+        input_kind="tile",
+        virtual_disposition="deferred",  # Header-only, no pixel read
+        sources=_PYVX_CRS_LIGHT + (_VECTORX + "ST_Crs.scala",),
+    ),
+    "st_setcrs": FnSpec(
+        "st_setcrs",
+        "gbx_st_setcrs",
+        "vector",
+        ("pure-core", "spark-path"),
+        {"srid": 4326},  # Default WGS84
+        core_fn=lambda col, a: None,  # Placeholder for pure-core
+        col_fn=lambda col, a: pyvx.st_setcrs(col, F.lit(a["srid"])),
+        core=True,
+        fingerprint=True,
+        input_kind="tile",
+        virtual_disposition="deferred",  # Header edit only
+        sources=_PYVX_CRS_LIGHT + (_VECTORX + "ST_SetCrs.scala",),
+    ),
+    "st_transformcrs": FnSpec(
+        "st_transformcrs",
+        "gbx_st_transformcrs",
+        "vector",
+        ("pure-core", "spark-path"),
+        {"source_crs": "EPSG:4326", "target_crs": "EPSG:3857"},
+        core_fn=lambda col, a: None,  # Placeholder for pure-core
+        col_fn=lambda col, a: pyvx.st_transformcrs(
+            col, F.lit(a["target_crs"]), F.lit(a["source_crs"])
+        ),
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        virtual_disposition="materialized",  # Full WKB transform
+        sources=_PYVX_CRS_LIGHT + (_VECTORX + "ST_TransformCrs.scala",),
+    ),
+    # --- Antimeridian Functions (Light-Only) ---
+    "st_shiftlongitude": FnSpec(
+        "st_shiftlongitude",
+        "gbx_st_shiftlongitude",
+        "vector",
+        ("spark-path",),
+        {"shift": 180},
+        col_fn=lambda col, a: pyvx.st_shiftlongitude(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_ANTIMERIDIAN_LIGHT,
+    ),
+    "st_split": FnSpec(
+        "st_split",
+        "gbx_st_split",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_split(col, F.lit(None)),  # Placeholder blade
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_ANTIMERIDIAN_LIGHT,
+    ),
+    "st_wrapx": FnSpec(
+        "st_wrapx",
+        "gbx_st_wrapx",
+        "vector",
+        ("spark-path",),
+        {"wrap_x_origin": 180, "wrap_direction": -180},
+        col_fn=lambda col, a: pyvx.st_wrapx(
+            col, F.lit(a["wrap_x_origin"]), F.lit(a["wrap_direction"])
+        ),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_ANTIMERIDIAN_LIGHT,
+    ),
+    # --- Validity Functions (Light-Only) ---
+    "st_explainvalidity": FnSpec(
+        "st_explainvalidity",
+        "gbx_st_explainvalidity",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_explainvalidity(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=False,  # Timing-only; text output
+        input_kind="tile",
+        sources=_PYVX_VALIDITY_LIGHT,
+    ),
+    "st_makevalid": FnSpec(
+        "st_makevalid",
+        "gbx_st_makevalid",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_makevalid(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_VALIDITY_LIGHT,
+    ),
+    # --- Cleaning Functions (Light-Only) ---
+    "st_node": FnSpec(
+        "st_node",
+        "gbx_st_node",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_node(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_CLEANING_LIGHT,
+    ),
+    "st_reduceprecision": FnSpec(
+        "st_reduceprecision",
+        "gbx_st_reduceprecision",
+        "vector",
+        ("spark-path",),
+        {"grid_size": 0.0001},
+        col_fn=lambda col, a: pyvx.st_reduceprecision(col, F.lit(a["grid_size"])),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_CLEANING_LIGHT,
+    ),
+    "st_removerepeatedpoints": FnSpec(
+        "st_removerepeatedpoints",
+        "gbx_st_removerepeatedpoints",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_removerepeatedpoints(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_CLEANING_LIGHT,
+    ),
+    "st_simplifypreservetopology": FnSpec(
+        "st_simplifypreservetopology",
+        "gbx_st_simplifypreservetopology",
+        "vector",
+        ("spark-path",),
+        {"tolerance": 0.001},
+        col_fn=lambda col, a: pyvx.st_simplifypreservetopology(col, F.lit(a["tolerance"])),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_CLEANING_LIGHT,
+    ),
+    "st_snap": FnSpec(
+        "st_snap",
+        "gbx_st_snap",
+        "vector",
+        ("spark-path",),
+        {"tolerance": 0.0001},  # Reference WKB generated per-call
+        col_fn=lambda col, a: pyvx.st_snap(
+            col, F.lit(shapely.geometry.box(-1, -1, 1, 1).wkb), F.lit(a["tolerance"])
+        ),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_CLEANING_LIGHT,
+    ),
+    # --- Coverage Functions (Light-Only) ---
+    "st_coverageisvalid": FnSpec(
+        "st_coverageisvalid",
+        "gbx_st_coverageisvalid",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_coverageisvalid(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=False,  # Timing-only; boolean result
+        input_kind="tile",
+        sources=_PYVX_COVERAGE_LIGHT,
+    ),
+    "st_coverageinvalidedges": FnSpec(
+        "st_coverageinvalidedges",
+        "gbx_st_coverageinvalidedges",
+        "vector",
+        ("spark-path",),
+        {},
+        col_fn=lambda col, a: pyvx.st_coverageinvalidedges(col),
+        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        core=False,
+        fingerprint=True,
+        input_kind="tile",
+        sources=_PYVX_COVERAGE_LIGHT,
+    ),
 }
 
 # Maps each tile-aggregator FnSpec to the bench.synth recipe whose tiles form its
@@ -3036,7 +3342,7 @@ def select(
 
 
 def registered_rst() -> "frozenset[str]":
-    """Canonical registered rst_* function names (the 107) from registered_functions.txt."""
+    """Canonical registered rst_* and st_* function names from registered_functions.txt."""
     from pathlib import Path
 
     # resolve repo root robustly from this file's location
@@ -3068,7 +3374,7 @@ def registered_rst() -> "frozenset[str]":
         if not s or s.startswith("#"):
             continue
         s = s[4:] if s.startswith("gbx_") else s
-        if s.startswith("rst_"):
+        if s.startswith("rst_") or s.startswith("st_"):
             names.add(s)
     return frozenset(names)
 

--- a/python/geobrix/src/databricks/labs/gbx/bench/spec.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/spec.py
@@ -3293,7 +3293,10 @@ REGISTRY: Dict[str, FnSpec] = {
         col_fn=lambda g, v, ext, a: pyvx.st_coverageinvalidedges(g),
         core_fn=lambda t, a: t,  # spark-path-only; no pure-core analogue
         core=False,
-        fingerprint=True,
+        # Timing-only: it returns WKB geometry, not a raster tile, and it is
+        # light-only (no heavy tier to parity-check), so skip the fingerprint
+        # (the raster fingerprint path can't open WKB bytes).
+        fingerprint=False,
         input_kind="geometry_aggregate",
         geometry_set="st_coverage",
         sources=_PYVX_COVERAGE_LIGHT,

--- a/python/geobrix/src/databricks/labs/gbx/bench/spec.py
+++ b/python/geobrix/src/databricks/labs/gbx/bench/spec.py
@@ -22,7 +22,6 @@ import shapely.wkb
 from pyspark.sql import functions as F
 
 from databricks.labs.gbx.pyrx import functions as prx
-from databricks.labs.gbx.pyvx import functions as pyvx
 from databricks.labs.gbx.pyrx.core import accessors
 from databricks.labs.gbx.pyrx.core import agg as agg_core
 from databricks.labs.gbx.pyrx.core import analysis as analysis_core
@@ -44,6 +43,7 @@ from databricks.labs.gbx.pyrx.core import (
     warp,
     xyz,
 )
+from databricks.labs.gbx.pyvx import functions as pyvx
 
 # Fixed 3x3 normalised mean kernel for rst_convolve. Hardcoded identically here
 # (Python core_fn + col_fn) and in the Scala BenchDispatch case so the two engines
@@ -2977,18 +2977,24 @@ REGISTRY: Dict[str, FnSpec] = {
     ),
     # --- VectorX (pyvx/vectorx) functions ---
     # Already-benched ST functions (MVT, TIN families).
+    # st_asmvt is a grouped-aggregate MVT encoder, so it is benched via the
+    # geometry_aggregate path (groupBy().agg(...)) — NOT as a scalar (a scalar
+    # col_fn would raise AnalysisException invoking a grouped-agg UDF). Its full
+    # light-vs-heavy parity bench is the dedicated --mvt-only leg; this FnSpec
+    # keeps it in the registered-function coverage set with the correct shape.
     "st_asmvt": FnSpec(
         "st_asmvt",
         "gbx_st_asmvt",
         "vector",
         ("spark-path",),
-        {"extent": 4096, "layer_name": "features"},
-        col_fn=lambda col, a: pyvx.st_asmvt(col, F.lit(None), F.lit(a["layer_name"])),
-        core_fn=lambda ds, a: None,  # Placeholder; spark-path only
+        {"layer_name": "features"},
+        col_fn=lambda g, v, ext, a: pyvx.st_asmvt(
+            g, F.lit(None), F.lit(a["layer_name"])
+        ),
+        core_fn=lambda ds, a: None,  # spark-path only
         core=False,
-        fingerprint=True,
-        fingerprint_kind="vector",
-        input_kind="geometry_scalar",
+        fingerprint=False,
+        input_kind="geometry_aggregate",
         geometry_set="srid_4326",
         sources=_PYVX_MVT_LIGHT + (_VECTORX + "ST_AsMvt.scala",),
     ),
@@ -3004,7 +3010,10 @@ REGISTRY: Dict[str, FnSpec] = {
         fingerprint=True,
         input_kind="geometry_scalar",
         geometry_set="srid_4326",
-        sources=(_PYVX + "_legacy.py", "src/main/scala/com/databricks/labs/gbx/vectorx/jts/legacy/expressions/ST_LegacyAsWKB.scala"),
+        sources=(
+            _PYVX + "_legacy.py",
+            "src/main/scala/com/databricks/labs/gbx/vectorx/jts/legacy/expressions/ST_LegacyAsWKB.scala",
+        ),
     ),
     "st_triangulate": FnSpec(
         "st_triangulate",
@@ -3025,7 +3034,9 @@ REGISTRY: Dict[str, FnSpec] = {
         "vector",
         ("spark-path",),
         {},
-        col_fn=lambda col, a: pyvx.st_interpolateelevationgeom(col, F.lit(None)),  # Placeholder points
+        col_fn=lambda col, a: pyvx.st_interpolateelevationgeom(
+            col, F.lit(None)
+        ),  # Placeholder points
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
@@ -3038,7 +3049,9 @@ REGISTRY: Dict[str, FnSpec] = {
         "vector",
         ("spark-path",),
         {},
-        col_fn=lambda col, a: pyvx.st_interpolateelevationbbox(col, F.lit(None)),  # Placeholder points
+        col_fn=lambda col, a: pyvx.st_interpolateelevationbbox(
+            col, F.lit(None)
+        ),  # Placeholder points
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,
@@ -3046,20 +3059,26 @@ REGISTRY: Dict[str, FnSpec] = {
         sources=(_PYVX + "_tin.py", _VECTORX + "ST_InterpolateElevationBBox.scala"),
     ),
     # 16 new vector function benchmarks: 1 heavy+light (asmvt_pyramid), 15 light-only
-    # (CRS, antimeridian, validity, cleaning, coverage families).
+    # st_asmvt_pyramid is a per-feature MVT tiling UDTF (one geometry -> many
+    # (z,x,y,mvt) rows). Benched via the geometry-input UDTF-LATERAL path:
+    #   SELECT t.* FROM <geom view> AS d, LATERAL
+    #     gbx_st_asmvt_pyramid(d.geom, NULL, min_z, max_z, layer) AS t
+    # (attrs=NULL -> geometry-only tiles; the full t.* fan-out is realized to noop).
+    # args order mirrors the UDTF eval signature (geom, attrs, min_z, max_z, layer);
+    # the leading `attrs: None` renders as the SQL NULL literal after d.geom.
     "st_asmvt_pyramid": FnSpec(
         "st_asmvt_pyramid",
         "gbx_st_asmvt_pyramid",
         "vector",
-        ("spark-path",),  # Spark-path only (UDTF); no pure-core
-        {"min_z": 0, "max_z": 14, "layer_name": "features"},
-        col_fn=lambda col, a: pyvx.st_asmvt_pyramid(
-            col, a["min_z"], a["max_z"], a["layer_name"]
-        ),
-        core_fn=lambda ds, a: None,  # Placeholder; spark-path-only
+        ("spark-path",),
+        {"attrs": None, "min_z": 0, "max_z": 5, "layer_name": "features"},
+        col_fn=lambda col, a: None,  # UDTF: invoked via SQL LATERAL, not a scalar
+        core_fn=lambda ds, a: None,
         core=False,
-        fingerprint=True,
-        input_kind="tile",
+        fingerprint=False,
+        input_kind="geometry",
+        geometry_set="srid_4326",
+        udtf=True,
         sources=_PYVX_MVT_LIGHT + (_VECTORX + "ST_AsMvtPyramid.scala",),
     ),
     # --- CRS Functions (Light-Only) ---
@@ -3238,7 +3257,9 @@ REGISTRY: Dict[str, FnSpec] = {
         "vector",
         ("spark-path",),
         {"tolerance": 0.001},
-        col_fn=lambda col, a: pyvx.st_simplifypreservetopology(col, F.lit(a["tolerance"])),
+        col_fn=lambda col, a: pyvx.st_simplifypreservetopology(
+            col, F.lit(a["tolerance"])
+        ),
         core_fn=lambda ds, a: None,  # Placeholder; spark-path only
         core=False,
         fingerprint=True,

--- a/python/geobrix/test/bench/test_compare.py
+++ b/python/geobrix/test/bench/test_compare.py
@@ -487,12 +487,10 @@ def test_pyrx_implemented_guards_against_binding_regression():
     # "no registered function lost its pyrx binding", NOT a brittle exact count.
     # Assert the meaningful invariant: every registered rst_ function has a pyrx
     # binding (so pyrx_implemented ⊇ the registered set), plus membership spot-checks.
-    from databricks.labs.gbx.bench import spec
-
     impl = c.pyrx_implemented()
-    registered = spec.registered_rst()
+    registered = c.registered_raster()
     missing = registered - impl
-    assert not missing, f"registered fns missing a pyrx binding: {sorted(missing)}"
+    assert not missing, f"registered rst_ fns missing a pyrx binding: {sorted(missing)}"
     assert len(impl) >= len(registered)
     assert "rst_slope" in impl
     assert "rst_merge" in impl
@@ -510,11 +508,9 @@ def test_coverage_block_reports_coverage_parity_gap_and_uncovered():
     md = c.coverage_block(cells)
     # Coverage: distinct fn count across all cells = 5, out of the registered rst_
     # total. Derive the denominator from the SAME source coverage_block uses
-    # (spec.registered_rst) so the "N / <total>" string matches whatever the code
-    # emits -- no magic literal.
-    from databricks.labs.gbx.bench import spec
-
-    total = len(spec.registered_rst())
+    # (compare.registered_raster -- rst_ only, excludes the pyvx st_ set) so the
+    # "N / <total>" string matches whatever the code emits -- no magic literal.
+    total = len(c.registered_raster())
     assert "Benchmark coverage:" in md
     assert f"/ {total}" in md
     assert f"5 / {total}" in md
@@ -539,9 +535,7 @@ def test_summarize_compare_includes_coverage_block():
         _cmp("rst_clip", "pure-core", 20.0, 10.0, 2.0, "na", ""),
     ]
     md = c.summarize_compare(cells, [], [], [])
-    from databricks.labs.gbx.bench import spec
-
-    total = len(spec.registered_rst())
+    total = len(c.registered_raster())
     assert "Coverage & parity" in md
     assert f"/ {total}" in md
     assert "Functional parity gap:** 0" in md

--- a/python/geobrix/test/bench/test_geometry_corpus.py
+++ b/python/geobrix/test/bench/test_geometry_corpus.py
@@ -161,6 +161,71 @@ def test_generate_corpus_persists_a_geometry_manifest(tmp_path):
             assert left <= p.x <= right and bottom <= p.y <= top
 
 
+def test_st_geometry_sets_are_generated(tmp_path):
+    # The geometry corpus must include ST function family geometry sets:
+    # st_validity (invalid geometries), st_antimeridian (crossing ±180°),
+    # st_cleaning (dense vertices), st_coverage (overlapping polygons).
+    # These are generated deterministically from the corpus seed and are
+    # accessible via runner._geometry_set_for().
+    dg.generate_corpus(
+        out_dir=tmp_path,
+        seed=42,
+        tile_px=[32],
+        bands=[1],
+        dtypes=["float32"],
+        srids=[4326],
+        nodata_fracs=[0.0],
+        row_rows=0,
+        row_tile_px=32,
+        row_bands=1,
+        row_dtype="float32",
+    )
+    geom_path = tmp_path / "geometry.json"
+    gc = m.GeometryCorpus.read(geom_path)
+
+    # Verify all 4 ST sets are present and non-empty
+    st_sets = ["st_validity", "st_antimeridian", "st_cleaning", "st_coverage"]
+    for name in st_sets:
+        assert name in gc.sets, f"Missing ST geometry set: {name}"
+        gset = gc.sets[name]
+        assert gset.srid == 4326
+        assert len(gset.boxes) > 0, f"{name} should have boxes"
+
+    # Verify st_validity geometries are actually invalid
+    validity_set = gc.sets["st_validity"]
+    if validity_set.boxes:
+        first_wkb, _ = validity_set.boxes[0]
+        first_geom = shapely.wkb.loads(first_wkb)
+        # At least the first geometry should be invalid (bowtie)
+        assert not first_geom.is_valid, "st_validity should contain invalid geometry"
+
+    # Verify st_antimeridian geometries cross ±180°
+    antimerid_set = gc.sets["st_antimeridian"]
+    if antimerid_set.boxes:
+        first_wkb, _ = antimerid_set.boxes[0]
+        first_geom = shapely.wkb.loads(first_wkb)
+        min_lon, _, max_lon, _ = first_geom.bounds
+        # Geometries should be in upper longitude range (near ±180°)
+        assert min_lon > 160 or max_lon > 160
+
+    # Verify st_cleaning geometries have dense vertices
+    cleaning_set = gc.sets["st_cleaning"]
+    if cleaning_set.boxes:
+        first_wkb, _ = cleaning_set.boxes[0]
+        first_geom = shapely.wkb.loads(first_wkb)
+        # Dense polygons should have many vertices
+        if hasattr(first_geom, "exterior"):
+            num_coords = len(list(first_geom.exterior.coords))
+        else:
+            num_coords = len(list(first_geom.coords))
+        assert num_coords > 30, "st_cleaning should have dense vertices"
+
+    # Verify runner can resolve the ST sets
+    for name in st_sets:
+        gset = rn._geometry_set_for(gc, None, name)
+        assert isinstance(gset, m.GeometrySet)
+
+
 def test_runner_feeds_geometry_set_to_geometry_input_kind(tmp_path):
     # The runner's input_kind == "geometry" branch loads the geometry corpus and
     # passes the tile's GeometrySet to core_fn(ds, args, geom). This smoke FnSpec

--- a/python/geobrix/test/bench/test_geometry_scalar_direct.py
+++ b/python/geobrix/test/bench/test_geometry_scalar_direct.py
@@ -1,11 +1,9 @@
 """Direct verification of geometry_scalar implementation without full bench infrastructure."""
 
-import json
 from pathlib import Path
-from databricks.labs.gbx.bench import manifest as m
+
 from databricks.labs.gbx.bench import runner as rn
 from databricks.labs.gbx.bench import spec as s
-import shapely.wkb
 
 
 def test_geometry_sets_loaded_from_corpus():
@@ -19,7 +17,9 @@ def test_geometry_sets_loaded_from_corpus():
     geom_corpus = rn._load_geometry_corpus(corpus_root)
     assert geom_corpus is not None
     assert len(geom_corpus.sets) > 0
-    print(f"Loaded {len(geom_corpus.sets)} geometry sets: {list(geom_corpus.sets.keys())}")
+    print(
+        f"Loaded {len(geom_corpus.sets)} geometry sets: {list(geom_corpus.sets.keys())}"
+    )
 
     # Verify each set has geometries
     for set_name, gset in geom_corpus.sets.items():
@@ -81,9 +81,15 @@ def test_st_specs_have_geometry_scalar_kind():
     fnspecs = s.select(functions=st_scalar_fns, set="full")
     print(f"\nChecked {len(fnspecs)} ST specs:")
     for fn in fnspecs:
-        print(f"  {fn.name:40s} input_kind={fn.input_kind:20s} geometry_set={getattr(fn, 'geometry_set', None)}")
-        assert fn.input_kind == "geometry_scalar", f"{fn.name} should be geometry_scalar, got {fn.input_kind}"
-        assert getattr(fn, 'geometry_set', None) is not None, f"{fn.name} should have geometry_set"
+        print(
+            f"  {fn.name:40s} input_kind={fn.input_kind:20s} geometry_set={getattr(fn, 'geometry_set', None)}"
+        )
+        assert (
+            fn.input_kind == "geometry_scalar"
+        ), f"{fn.name} should be geometry_scalar, got {fn.input_kind}"
+        assert (
+            getattr(fn, "geometry_set", None) is not None
+        ), f"{fn.name} should have geometry_set"
 
 
 def test_col_fn_produces_real_output():
@@ -106,9 +112,11 @@ def test_col_fn_produces_real_output():
         if validity_set.boxes:
             wkb = validity_set.boxes[0][0]
             geom = shapely.wkb.loads(wkb)
-            print(f"\n1. VALIDITY FUNCTION (st_makevalid):")
-            print(f"   Input:  valid={geom.is_valid}, coords={len(list(geom.exterior.coords))} pts")
-            print(f"   Expected: output geometry with no self-intersections")
+            print("\n1. VALIDITY FUNCTION (st_makevalid):")
+            print(
+                f"   Input:  valid={geom.is_valid}, coords={len(list(geom.exterior.coords))} pts"
+            )
+            print("   Expected: output geometry with no self-intersections")
 
     # Example 2: Antimeridian (st_shiftlongitude)
     if geom_corpus and "st_antimeridian" in geom_corpus.sets:
@@ -117,10 +125,10 @@ def test_col_fn_produces_real_output():
             wkb = antimeridian_set.boxes[0][0]
             geom = shapely.wkb.loads(wkb)
             bounds = geom.bounds  # (minx, miny, maxx, maxy)
-            print(f"\n2. ANTIMERIDIAN FUNCTION (st_shiftlongitude):")
+            print("\n2. ANTIMERIDIAN FUNCTION (st_shiftlongitude):")
             print(f"   Input:  bounds={bounds}")
             print(f"   Crosses antimeridian: {bounds[0] > bounds[2]}")
-            print(f"   Expected: output geometry with coordinates shifted by 180°")
+            print("   Expected: output geometry with coordinates shifted by 180°")
 
     # Example 3: Cleaning (st_simplifypreservetopology)
     if geom_corpus and "st_cleaning" in geom_corpus.sets:
@@ -128,17 +136,17 @@ def test_col_fn_produces_real_output():
         if cleaning_set.boxes:
             wkb = cleaning_set.boxes[0][0]
             geom = shapely.wkb.loads(wkb)
-            print(f"\n3. CLEANING FUNCTION (st_simplifypreservetopology):")
+            print("\n3. CLEANING FUNCTION (st_simplifypreservetopology):")
             print(f"   Input:  coords={len(list(geom.exterior.coords))} pts")
-            print(f"   Expected: output with fewer vertices (tolerance=0.001)")
+            print("   Expected: output with fewer vertices (tolerance=0.001)")
 
     # Example 4: Coverage (st_coverageinvalidedges)
     if geom_corpus and "st_coverage" in geom_corpus.sets:
         coverage_set = geom_corpus.sets["st_coverage"]
         if coverage_set.boxes:
-            print(f"\n4. COVERAGE FUNCTION (st_coverageinvalidedges):")
+            print("\n4. COVERAGE FUNCTION (st_coverageinvalidedges):")
             print(f"   Input:  {len(coverage_set.boxes)} polygons in coverage")
-            print(f"   Expected: output geometry collection of invalid edges (if any)")
+            print("   Expected: output geometry collection of invalid edges (if any)")
 
     # Example 5: CRS (st_transformcrs)
     if geom_corpus and "srid_4326" in geom_corpus.sets:
@@ -147,9 +155,9 @@ def test_col_fn_produces_real_output():
             wkb = crs_set.boxes[0][0]
             geom = shapely.wkb.loads(wkb)
             bounds = geom.bounds
-            print(f"\n5. CRS FUNCTION (st_transformcrs):")
+            print("\n5. CRS FUNCTION (st_transformcrs):")
             print(f"   Input:  EPSG:4326 bounds={bounds}")
-            print(f"   Expected: output in EPSG:3857 (Web Mercator)")
+            print("   Expected: output in EPSG:3857 (Web Mercator)")
 
     print("\n" + "=" * 60)
     print("All geometry transformation examples prepared from corpus.")

--- a/python/geobrix/test/bench/test_geometry_scalar_direct.py
+++ b/python/geobrix/test/bench/test_geometry_scalar_direct.py
@@ -1,0 +1,164 @@
+"""Direct verification of geometry_scalar implementation without full bench infrastructure."""
+
+import json
+from pathlib import Path
+from databricks.labs.gbx.bench import manifest as m
+from databricks.labs.gbx.bench import runner as rn
+from databricks.labs.gbx.bench import spec as s
+import shapely.wkb
+
+
+def test_geometry_sets_loaded_from_corpus():
+    """Verify that geometry sets can be loaded from the local corpus."""
+    # The corpus is at geobrix/sample-data/Volumes/main/default/bench-corpus
+    # We're in geobrix/python/geobrix/test/bench/, so go up 4 levels then to sample-data
+    test_file = Path(__file__)
+    repo_root = test_file.parent.parent.parent.parent.parent  # Up to geobrix repo root
+    corpus_root = repo_root / "sample-data/Volumes/main/default/bench-corpus"
+    print(f"Looking for corpus at: {corpus_root}")
+    geom_corpus = rn._load_geometry_corpus(corpus_root)
+    assert geom_corpus is not None
+    assert len(geom_corpus.sets) > 0
+    print(f"Loaded {len(geom_corpus.sets)} geometry sets: {list(geom_corpus.sets.keys())}")
+
+    # Verify each set has geometries
+    for set_name, gset in geom_corpus.sets.items():
+        if gset.boxes:
+            print(f"  {set_name}: {len(gset.boxes)} boxes")
+        if gset.points:
+            print(f"  {set_name}: {len(gset.points)} points")
+        if gset.zpoints:
+            print(f"  {set_name}: {len(gset.zpoints)} zpoints")
+
+
+def test_geometry_set_for_lookup():
+    """Verify _geometry_set_for lookup works."""
+    test_file = Path(__file__)
+    repo_root = test_file.parent.parent.parent.parent.parent  # Up to geobrix repo root
+    corpus_root = repo_root / "sample-data/Volumes/main/default/bench-corpus"
+    geom_corpus = rn._load_geometry_corpus(corpus_root)
+
+    # Create a mock TileEntry
+    class MockTile:
+        path = "rows/r0.tif"
+        srid = 4326
+
+    tile = MockTile()
+
+    # Lookup by explicit name
+    gset = rn._geometry_set_for(geom_corpus, tile, geometry_set_override="st_validity")
+    assert gset is not None
+    assert len(gset.boxes) > 0 or len(gset.points) > 0
+    print(f"Found st_validity set with {len(gset.boxes)} boxes")
+
+    # Lookup by srid fallback
+    gset_default = rn._geometry_set_for(geom_corpus, tile, geometry_set_override=None)
+    assert gset_default is not None
+    print(f"Found default set for SRID 4326 with {len(gset_default.boxes)} boxes")
+
+
+def test_st_specs_have_geometry_scalar_kind():
+    """Verify ST specs have geometry_scalar input_kind."""
+    st_scalar_fns = [
+        "st_makevalid",
+        "st_explainvalidity",
+        "st_shiftlongitude",
+        "st_transformcrs",
+        "st_node",
+        "st_reduceprecision",
+        "st_removerepeatedpoints",
+        "st_simplifypreservetopology",
+        "st_snap",
+        "st_crs",
+        "st_setcrs",
+        "st_split",
+        "st_wrapx",
+        "st_coverageisvalid",
+        "st_coverageinvalidedges",
+        "st_legacyaswkb",
+    ]
+
+    fnspecs = s.select(functions=st_scalar_fns, set="full")
+    print(f"\nChecked {len(fnspecs)} ST specs:")
+    for fn in fnspecs:
+        print(f"  {fn.name:40s} input_kind={fn.input_kind:20s} geometry_set={getattr(fn, 'geometry_set', None)}")
+        assert fn.input_kind == "geometry_scalar", f"{fn.name} should be geometry_scalar, got {fn.input_kind}"
+        assert getattr(fn, 'geometry_set', None) is not None, f"{fn.name} should have geometry_set"
+
+
+def test_col_fn_produces_real_output():
+    """Verify col_fn produces real work by showing geometry transformations."""
+    import shapely.geometry
+    import shapely.wkb
+
+    # Load geometry corpus to show real-world examples
+    test_file = Path(__file__)
+    repo_root = test_file.parent.parent.parent.parent.parent
+    corpus_root = repo_root / "sample-data/Volumes/main/default/bench-corpus"
+    geom_corpus = rn._load_geometry_corpus(corpus_root)
+
+    print("\nGeometry Scalar Transformation Evidence:")
+    print("=" * 60)
+
+    # Example 1: Validity (st_makevalid)
+    if geom_corpus and "st_validity" in geom_corpus.sets:
+        validity_set = geom_corpus.sets["st_validity"]
+        if validity_set.boxes:
+            wkb = validity_set.boxes[0][0]
+            geom = shapely.wkb.loads(wkb)
+            print(f"\n1. VALIDITY FUNCTION (st_makevalid):")
+            print(f"   Input:  valid={geom.is_valid}, coords={len(list(geom.exterior.coords))} pts")
+            print(f"   Expected: output geometry with no self-intersections")
+
+    # Example 2: Antimeridian (st_shiftlongitude)
+    if geom_corpus and "st_antimeridian" in geom_corpus.sets:
+        antimeridian_set = geom_corpus.sets["st_antimeridian"]
+        if antimeridian_set.boxes:
+            wkb = antimeridian_set.boxes[0][0]
+            geom = shapely.wkb.loads(wkb)
+            bounds = geom.bounds  # (minx, miny, maxx, maxy)
+            print(f"\n2. ANTIMERIDIAN FUNCTION (st_shiftlongitude):")
+            print(f"   Input:  bounds={bounds}")
+            print(f"   Crosses antimeridian: {bounds[0] > bounds[2]}")
+            print(f"   Expected: output geometry with coordinates shifted by 180°")
+
+    # Example 3: Cleaning (st_simplifypreservetopology)
+    if geom_corpus and "st_cleaning" in geom_corpus.sets:
+        cleaning_set = geom_corpus.sets["st_cleaning"]
+        if cleaning_set.boxes:
+            wkb = cleaning_set.boxes[0][0]
+            geom = shapely.wkb.loads(wkb)
+            print(f"\n3. CLEANING FUNCTION (st_simplifypreservetopology):")
+            print(f"   Input:  coords={len(list(geom.exterior.coords))} pts")
+            print(f"   Expected: output with fewer vertices (tolerance=0.001)")
+
+    # Example 4: Coverage (st_coverageinvalidedges)
+    if geom_corpus and "st_coverage" in geom_corpus.sets:
+        coverage_set = geom_corpus.sets["st_coverage"]
+        if coverage_set.boxes:
+            print(f"\n4. COVERAGE FUNCTION (st_coverageinvalidedges):")
+            print(f"   Input:  {len(coverage_set.boxes)} polygons in coverage")
+            print(f"   Expected: output geometry collection of invalid edges (if any)")
+
+    # Example 5: CRS (st_transformcrs)
+    if geom_corpus and "srid_4326" in geom_corpus.sets:
+        crs_set = geom_corpus.sets["srid_4326"]
+        if crs_set.boxes:
+            wkb = crs_set.boxes[0][0]
+            geom = shapely.wkb.loads(wkb)
+            bounds = geom.bounds
+            print(f"\n5. CRS FUNCTION (st_transformcrs):")
+            print(f"   Input:  EPSG:4326 bounds={bounds}")
+            print(f"   Expected: output in EPSG:3857 (Web Mercator)")
+
+    print("\n" + "=" * 60)
+    print("All geometry transformation examples prepared from corpus.")
+    print("Real execution would apply col_fn to these geometries.")
+
+
+if __name__ == "__main__":
+    test_geometry_sets_loaded_from_corpus()
+    test_geometry_set_for_lookup()
+    test_st_specs_have_geometry_scalar_kind()
+    test_col_fn_produces_real_output()
+    print("\nAll direct verification tests completed.")

--- a/python/geobrix/test/bench/test_geometry_scalar_direct.py
+++ b/python/geobrix/test/bench/test_geometry_scalar_direct.py
@@ -73,9 +73,9 @@ def test_st_specs_have_geometry_scalar_kind():
         "st_setcrs",
         "st_split",
         "st_wrapx",
-        "st_coverageisvalid",
-        "st_coverageinvalidedges",
         "st_legacyaswkb",
+        # NB: st_coverageisvalid/coverageinvalidedges are geometry_AGGREGATE
+        # (grouped), not geometry_scalar -- asserted separately, not here.
     ]
 
     fnspecs = s.select(functions=st_scalar_fns, set="full")

--- a/python/geobrix/test/bench/test_geometry_set_routing.py
+++ b/python/geobrix/test/bench/test_geometry_set_routing.py
@@ -1,0 +1,157 @@
+"""Test geometry set routing for VectorX ST functions in the benchmark spec."""
+
+import pytest
+from pathlib import Path
+
+from databricks.labs.gbx.bench import manifest as m
+from databricks.labs.gbx.bench import runner
+
+
+def test_geometry_set_field_added_to_fnspec():
+    """Verify that FnSpec has the geometry_set field."""
+    from databricks.labs.gbx.bench.spec import FnSpec, _BOTH
+
+    # Create a simple FnSpec with geometry_set
+    fs = FnSpec(
+        name="test_fn",
+        sql_name="gbx_test_fn",
+        category="test",
+        modes=_BOTH,
+        geometry_set="test_set",
+    )
+    assert fs.geometry_set == "test_set"
+
+    # Verify None is the default
+    fs_no_geom = FnSpec(
+        name="test_fn",
+        sql_name="gbx_test_fn",
+        category="test",
+        modes=_BOTH,
+    )
+    assert fs_no_geom.geometry_set is None
+
+
+def test_geometry_set_override_in_geometry_set_for():
+    """Verify _geometry_set_for honors the geometry_set_override parameter."""
+    from databricks.labs.gbx.bench.manifest import GeometrySet, GeometryCorpus
+
+    # Create a minimal corpus with two sets
+    set1 = GeometrySet(
+        srid=4326,
+        source_tile="tile1.tif",
+        boxes=[(b"\x00", 1.0)],
+        points=[],
+        zpoints=[],
+    )
+    set2 = GeometrySet(
+        srid=27700,
+        source_tile="tile2.tif",
+        boxes=[(b"\x01", 2.0)],
+        points=[],
+        zpoints=[],
+    )
+    corpus = GeometryCorpus(seed=1, srid=4326, source_tile="tile1.tif", sets={"set1": set1, "set2": set2})
+
+    # Create a dummy tile entry
+    from databricks.labs.gbx.bench.manifest import TileEntry
+
+    te = TileEntry(path="tile1.tif", cellid=0, srid=4326, dtype="float32", bands=2, tile_px=256, nodata_frac=0.0)
+
+    # Test 1: Without override, should match by source_tile
+    result = runner._geometry_set_for(corpus, te, None)
+    assert result == set1
+
+    # Test 2: With override to set2, should return set2
+    result = runner._geometry_set_for(corpus, te, "set2")
+    assert result == set2
+
+    # Test 3: With invalid override, should raise ValueError
+    with pytest.raises(ValueError, match="geometry_set 'invalid' not found"):
+        runner._geometry_set_for(corpus, te, "invalid")
+
+
+def test_st_functions_have_geometry_set():
+    """Verify that all required ST functions have geometry_set configured."""
+    from databricks.labs.gbx.bench.spec import REGISTRY
+
+    # Expected geometry_set assignments per the task
+    expected_mappings = {
+        "st_validity": ["st_makevalid", "st_explainvalidity"],
+        "st_antimeridian": ["st_shiftlongitude", "st_wrapx", "st_split"],
+        "st_cleaning": [
+            "st_simplifypreservetopology",
+            "st_removerepeatedpoints",
+            "st_reduceprecision",
+            "st_node",
+            "st_snap",
+        ],
+        "st_coverage": ["st_coverageisvalid", "st_coverageinvalidedges"],
+        # CRS fns operate on a geometry, so they route to a valid box set (srid_4326).
+        "srid_4326": ["st_crs", "st_setcrs", "st_transformcrs"],
+    }
+
+    for geom_set, fn_names in expected_mappings.items():
+        for fn_name in fn_names:
+            assert fn_name in REGISTRY, f"Function {fn_name} not found in REGISTRY"
+            spec = REGISTRY[fn_name]
+            actual_geom_set = getattr(spec, "geometry_set", None)
+            assert (
+                actual_geom_set == geom_set
+            ), f"{fn_name} has geometry_set={actual_geom_set}, expected {geom_set}"
+
+
+def test_geometry_set_for_with_default_matching():
+    """Verify _geometry_set_for default behavior (no override) still works."""
+    from databricks.labs.gbx.bench.manifest import GeometrySet, GeometryCorpus, TileEntry
+
+    # Create corpus with sets keyed by srid
+    set_4326 = GeometrySet(
+        srid=4326,
+        source_tile="tile_4326.tif",
+        boxes=[(b"\x00", 1.0)],
+        points=[],
+        zpoints=[],
+    )
+    set_27700 = GeometrySet(
+        srid=27700,
+        source_tile="tile_27700.tif",
+        boxes=[(b"\x01", 2.0)],
+        points=[],
+        zpoints=[],
+    )
+    corpus = GeometryCorpus(
+        seed=1,
+        srid=4326,
+        source_tile="tile_4326.tif",
+        sets={"by_source": set_4326, "by_srid": set_27700},
+    )
+
+    # Tile with matching source_tile
+    te1 = TileEntry(
+        path="tile_4326.tif",
+        cellid=0,
+        srid=4326,
+        dtype="float32",
+        bands=2,
+        tile_px=256,
+        nodata_frac=0.0,
+    )
+    result = runner._geometry_set_for(corpus, te1, None)
+    assert result == set_4326
+
+    # Tile with no matching source_tile but matching srid (27700)
+    te2 = TileEntry(
+        path="other_tile.tif",
+        cellid=1,
+        srid=27700,
+        dtype="float32",
+        bands=2,
+        tile_px=256,
+        nodata_frac=0.0,
+    )
+    result = runner._geometry_set_for(corpus, te2, None)
+    assert result == set_27700
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/geobrix/test/bench/test_geometry_set_routing.py
+++ b/python/geobrix/test/bench/test_geometry_set_routing.py
@@ -1,15 +1,13 @@
 """Test geometry set routing for VectorX ST functions in the benchmark spec."""
 
 import pytest
-from pathlib import Path
 
-from databricks.labs.gbx.bench import manifest as m
 from databricks.labs.gbx.bench import runner
 
 
 def test_geometry_set_field_added_to_fnspec():
     """Verify that FnSpec has the geometry_set field."""
-    from databricks.labs.gbx.bench.spec import FnSpec, _BOTH
+    from databricks.labs.gbx.bench.spec import _BOTH, FnSpec
 
     # Create a simple FnSpec with geometry_set
     fs = FnSpec(
@@ -33,7 +31,7 @@ def test_geometry_set_field_added_to_fnspec():
 
 def test_geometry_set_override_in_geometry_set_for():
     """Verify _geometry_set_for honors the geometry_set_override parameter."""
-    from databricks.labs.gbx.bench.manifest import GeometrySet, GeometryCorpus
+    from databricks.labs.gbx.bench.manifest import GeometryCorpus, GeometrySet
 
     # Create a minimal corpus with two sets
     set1 = GeometrySet(
@@ -50,12 +48,22 @@ def test_geometry_set_override_in_geometry_set_for():
         points=[],
         zpoints=[],
     )
-    corpus = GeometryCorpus(seed=1, srid=4326, source_tile="tile1.tif", sets={"set1": set1, "set2": set2})
+    corpus = GeometryCorpus(
+        seed=1, srid=4326, source_tile="tile1.tif", sets={"set1": set1, "set2": set2}
+    )
 
     # Create a dummy tile entry
     from databricks.labs.gbx.bench.manifest import TileEntry
 
-    te = TileEntry(path="tile1.tif", cellid=0, srid=4326, dtype="float32", bands=2, tile_px=256, nodata_frac=0.0)
+    te = TileEntry(
+        path="tile1.tif",
+        cellid=0,
+        srid=4326,
+        dtype="float32",
+        bands=2,
+        tile_px=256,
+        nodata_frac=0.0,
+    )
 
     # Test 1: Without override, should match by source_tile
     result = runner._geometry_set_for(corpus, te, None)
@@ -102,7 +110,11 @@ def test_st_functions_have_geometry_set():
 
 def test_geometry_set_for_with_default_matching():
     """Verify _geometry_set_for default behavior (no override) still works."""
-    from databricks.labs.gbx.bench.manifest import GeometrySet, GeometryCorpus, TileEntry
+    from databricks.labs.gbx.bench.manifest import (
+        GeometryCorpus,
+        GeometrySet,
+        TileEntry,
+    )
 
     # Create corpus with sets keyed by srid
     set_4326 = GeometrySet(

--- a/python/geobrix/test/bench/test_scorecard.py
+++ b/python/geobrix/test/bench/test_scorecard.py
@@ -51,7 +51,7 @@ def test_scorecard_empty_store(tmp_path):
     out = compare.scorecard_from_store(root=tmp_path)
     # Denominator derived from the SAME source the scorecard uses
     # (spec.registered_rst) so it matches whatever the code emits -- no literal.
-    total = len(spec.registered_rst())
+    total = len(compare.registered_raster())
     assert "Benchmark coverage:** 0" in out
     assert f"/ {total}" in out
     # nothing covered -> every registered fn listed as not-yet-covered
@@ -86,7 +86,7 @@ def test_scorecard_aggregates_over_store(tmp_path):
     }
     out = compare.scorecard_from_store(root=tmp_path, specs_by_name=specs_by_name)
 
-    total = len(spec.registered_rst())
+    total = len(compare.registered_raster())
     assert f"Benchmark coverage:** 3 / {total}" in out
     # parity: 1 exact, 1 divergent, 1 timing-only (na)
     assert "exact 1" in out
@@ -104,7 +104,7 @@ def test_scorecard_aggregates_over_store(tmp_path):
 def test_scorecard_default_specs_from_registry(tmp_path):
     # With no specs_by_name override the scorecard resolves specs from the live
     # registry; a record for a real registered fn must not crash and must show up.
-    reg = sorted(spec.registered_rst())
+    reg = sorted(compare.registered_raster())
     fn = reg[0]
     specs_by_name = {s.name: s for s in spec.select(set="full")}
     _write(
@@ -114,7 +114,7 @@ def test_scorecard_default_specs_from_registry(tmp_path):
         cells=[_cell("exact", 0.0, 2.0)],
     )
     out = compare.scorecard_from_store(root=tmp_path)
-    total = len(spec.registered_rst())
+    total = len(compare.registered_raster())
     assert f"Benchmark coverage:** 1 / {total}" in out
     assert fn in out
 

--- a/python/geobrix/test/bench/test_spec.py
+++ b/python/geobrix/test/bench/test_spec.py
@@ -83,7 +83,9 @@ def test_select_core_is_subset_of_full():
     full = {f.name for f in s.select(set="full")}
     assert core
     assert core <= full
-    assert len(core) == 19  # core == the 19 representative RST fns (ST fns are spark-path-only, not core)
+    assert (
+        len(core) == 19
+    )  # core == the 19 representative RST fns (ST fns are spark-path-only, not core)
     assert "rst_slope" in core and "rst_ndvi" in core
 
 

--- a/python/geobrix/test/bench/test_spec.py
+++ b/python/geobrix/test/bench/test_spec.py
@@ -83,7 +83,7 @@ def test_select_core_is_subset_of_full():
     full = {f.name for f in s.select(set="full")}
     assert core
     assert core <= full
-    assert len(core) == 21  # core == all current representative functions (rst + st)
+    assert len(core) == 19  # core == the 19 representative RST fns (ST fns are spark-path-only, not core)
     assert "rst_slope" in core and "rst_ndvi" in core
 
 

--- a/python/geobrix/test/bench/test_spec.py
+++ b/python/geobrix/test/bench/test_spec.py
@@ -83,7 +83,7 @@ def test_select_core_is_subset_of_full():
     full = {f.name for f in s.select(set="full")}
     assert core
     assert core <= full
-    assert len(core) == 19  # core == all current representative functions
+    assert len(core) == 21  # core == all current representative functions (rst + st)
     assert "rst_slope" in core and "rst_ndvi" in core
 
 


### PR DESCRIPTION
## Summary

Post-0.5.0-release work on `beta/0.5.0` (17 commits since the merged PR #72). **No product or runtime code changed** — only benchmark tooling, documentation, and a session hook — so the published 0.5.0 wheel/JAR are unaffected.

### VectorX ST benchmarking (the bulk)

- Registered the full `gbx_st_*` set in the bench suite and captured **real light-tier spark-path numbers** across the ST families (validity, cleaning, coverage, CRS, antimeridian, MVT encoding).
- Added a **geometry-input UDTF-LATERAL path** to the harness and benched `st_asmvt_pyramid` (~2.6 ms per input geometry, ~390 geoms/s; z 0–5 pyramid fan-out) — closing the last ST-function bench gap.
- Made the ST geometry corpus **reproducible from code** — `datagen` now generates the antimeridian / validity / cleaning / coverage sets deterministically instead of relying on a manually-staged file.
- Correctness fixes: `st_split` bench blade must be a LineString; `st_asmvt` declared as a grouped-aggregate (was mis-declared scalar); coverage validity wired as a grouped-aggregate; `st_coverageinvalidedges` treated as timing-only (WKB output).
- Populated the **benchmarking** Vector tab and the **performance** page; removed the Deferred-functions section.

### Docs & positioning

- Refreshed package positioning across README, the homepage, the Functions Overview, and each package page (RasterX / GridX / VectorX / VizX), including `plot_mosaic` under VizX.
- Dropped "(beta)" from the version descriptor.

### Tooling

- Added a non-blocking `.claude/settings.json` hook that reminds contributors to run `gbx:review:round` (scoped Isaac Review) before a branch is pushed.

### Verification

- Bench unit tests green (113 pass); Python lint gate clean; `st_asmvt_pyramid` benched end-to-end on a cluster.
- Scoped Isaac Review (`--full`, cache-ignored) on the new commits: **0 findings**.

This pull request and its description were written by Isaac.
