### PR TITLE
docs: fix antimeridian example + add Serverless force-reload tip

### DIFF
--- a/docs/docs/api/antimeridian.mdx
+++ b/docs/docs/api/antimeridian.mdx
@@ -28,16 +28,16 @@ The full pattern runs four steps:
 
 1. **Shift** the polygon from `[-180, 180]` into `[0, 360]` longitude space with `gbx_st_shiftlongitude`. This makes a crossing polygon contiguous — its western vertices (e.g. −170°) move to 190°, and the entire shape now sits around the 180° line without any coordinate-wrap artefacts.
 2. **Split** the contiguous polygon at the 180° meridian with `gbx_st_split`. The result is a `GEOMETRYCOLLECTION` containing two separate pieces.
-3. **Explode** the collection into individual rows with the built-in `ST_Dump`.
-4. **Wrap only the eastern pieces** back into `[-180, 0]` with `gbx_st_wrapx`. The conditional `CASE WHEN ST_XMax(piece) > 180` is essential: the eastern piece (all x ≥ 180) needs wrapping; the western piece (all x ≤ 180) is already in standard longitude range and must not be touched. Applying `gbx_st_wrapx` uniformly to both pieces would shift the western piece's 180° shared edge to −180°, producing a 350°-wide polygon instead of a clean 10° strip.
+3. **Dump** the collection with the built-in `ST_Dump`, which returns the pieces as an `ARRAY<GEOMETRY>`. Index them positionally — `geom_split[0]` and `geom_split[1]`.
+4. **Wrap only the eastern piece** back into `[-180, 0]` with `gbx_st_wrapx`. The conditional `CASE WHEN ST_XMax(piece) > 180` is essential: the eastern piece (all x ≥ 180) needs wrapping; the western piece (all x ≤ 180) is already in standard longitude range and must not be touched. Applying `gbx_st_wrapx` uniformly to both pieces would shift the western piece's 180° shared edge to −180°, producing a 350°-wide polygon instead of a clean 10° strip.
 
-The final `ST_Union` / `ST_Multi` reassembles the normalized pieces into a `MULTIPOLYGON`.
+The final `ST_Union(geom_0, geom_1)` / `ST_Multi` reassembles the two normalized pieces into a `MULTIPOLYGON`.
 
 ## WKB ↔ GEOMETRY bridge
 
 GeoBrix functions operate on `BINARY` (WKB/EWKB). The built-in product functions (`ST_Dump`, `ST_XMax`, `ST_Union`, `ST_Multi`, `ST_AsText`) operate on the product's `GEOMETRY` type. Where the two meet, bridge with:
 
-- `ST_GeomFromWKB(wkb_column)` — converts GeoBrix BINARY output to a product `GEOMETRY` value
+- `ST_GeomFromWKB(wkb_column, 4326)` — converts GeoBrix BINARY output to a product `GEOMETRY` value. Pass the SRID (`4326`) so the pieces share a CRS; `ST_Union` requires its inputs to be in the same spatial reference.
 - `ST_AsBinary(geometry_column)` — converts a product `GEOMETRY` value back to BINARY for GeoBrix input
 
 The pattern below shows both bridges in context.

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -28,6 +28,16 @@ GeoBrix Light uses **explicit, runtime-pinned extras** — there is no bare `[li
 
 :::tip On Serverless, use `geobrix[light_env6]`
 **Environment v6 is recommended for Serverless.** Install `geobrix[light_env6]` and set the environment version to **6** — in the Environment side panel, or `environment_version: "6"` on a job. For an env 5 Serverless cluster, use `geobrix[light_env5]` instead.
+
+**Force-reload on Serverless without touching dependencies.** To swap in fresh wheel bytes during an interactive session, run this in a cell towards the top of your notebook:
+
+```python
+%pip install --force-reinstall --no-deps "geobrix[light_env6] @ file:///Volumes/<catalog>/<schema>/<volume>/geobrix/geobrix-<version>-py3-none-any.whl"
+%pip install "geobrix[light_env6] @ file:///Volumes/<catalog>/<schema>/<volume>/geobrix/geobrix-<version>-py3-none-any.whl"
+dbutils.library.restartPython()
+```
+
+Keep `--no-deps` alongside `--force-reinstall` — without it, pip reinstalls pyspark and other preinstalled packages and Serverless fails the cell. The second, plain install then restores any dependencies the first (deps-skipped) step left out.
 :::
 
 <Tabs groupId="gbx-tier" queryString="tier" className="gbx-tier-tabs">

--- a/docs/tests/python/api/vectorx_functions_sql.py
+++ b/docs/tests/python/api/vectorx_functions_sql.py
@@ -336,42 +336,55 @@ def antimeridian_pattern_sql_example():
     1. ``gbx_st_shiftlongitude`` — shift [-180,180] → [0,360] so the polygon
        becomes contiguous (x ∈ [170, 190]) and cuttable at x=180.
     2. ``gbx_st_split`` — cut at the 180° meridian into a GeometryCollection.
-    3. ``ST_Dump`` — explode the collection into individual polygon rows.
-    4. ``CASE WHEN ST_XMax(piece) > 180 THEN gbx_st_wrapx(…) ELSE ST_AsBinary(piece) END``
+    3. ``ST_Dump`` — returns the collection's pieces as an ``ARRAY<GEOMETRY>``;
+       index them as ``geom_split[0]`` / ``geom_split[1]``.
+    4. ``CASE WHEN ST_XMax(piece) > 180 THEN ST_GeomFromWKB(gbx_st_wrapx(…), 4326) ELSE piece END``
        — wrap only the eastern piece (x ≥ 180) back to [-180, 0]; leave the
        western piece (all x ≤ 180) unchanged.  Applying wrapx uniformly would
        move the western piece's x=180 edge to x=-180, producing a 350°-wide
        polygon instead of a clean 10° strip.
-    5. ``ST_Union`` / ``ST_Multi`` — reassemble into a clean MULTIPOLYGON.
+    5. ``ST_Union(geom_0, geom_1)`` / ``ST_Multi`` — reassemble into a clean
+       MULTIPOLYGON.  The ``4326`` SRID on every ``ST_GeomFromWKB`` bridge keeps
+       both pieces in the same CRS so ``ST_Union`` accepts them.
+
+    Runs on Databricks Runtime 17.3+ where the built-in ``ST_Dump`` / ``ST_XMax``
+    / ``ST_Union`` / ``ST_Multi`` / ``ST_GeomFromWKB`` functions are available.
     """
     return """
 WITH raw AS (
-  SELECT 'POLYGON((170 -10, -170 -10, -170 10, 170 10, 170 -10))' AS geom
+  SELECT 'POLYGON((170 -10, -170 -10, -170 10, 170 10, 170 -10))' AS wkt
 ),
 pieces AS (
-  SELECT (ST_Dump(ST_GeomFromWKB(
-           gbx_st_split(gbx_st_shiftlongitude(geom),
-                        'LINESTRING(180 -90, 180 90)')))).geom AS piece
+  SELECT ST_Dump(
+           ST_GeomFromWKB(
+             gbx_st_split(gbx_st_shiftlongitude(wkt), 'LINESTRING(180 -90, 180 90)'),
+             4326
+           )
+         ) AS geom_split
   FROM raw
 ),
 parts AS (
-  SELECT CASE
-           WHEN ST_XMax(piece) > 180
-             THEN gbx_st_wrapx(ST_AsBinary(piece), 180, -360)
-           ELSE ST_AsBinary(piece)
-         END AS geom
-  FROM pieces)
-SELECT ST_AsText(ST_Multi(ST_Union(ST_GeomFromWKB(geom)))) AS normalized FROM parts;
+  SELECT
+    CASE WHEN ST_XMax(geom_split[0]) > 180
+         THEN ST_GeomFromWKB(gbx_st_wrapx(ST_AsBinary(geom_split[0]), 180, -360), 4326)
+         ELSE geom_split[0]
+    END AS geom_0,
+    CASE WHEN ST_XMax(geom_split[1]) > 180
+         THEN ST_GeomFromWKB(gbx_st_wrapx(ST_AsBinary(geom_split[1]), 180, -360), 4326)
+         ELSE geom_split[1]
+    END AS geom_1
+  FROM pieces
+)
+SELECT ST_AsText(ST_Multi(ST_Union(geom_0, geom_1))) AS normalized FROM parts;
 """
 
 
 antimeridian_pattern_sql_example_output = """
-+------------------+
-|normalized        |
-+------------------+
-|MULTIPOLYGON (...)|
-+------------------+
-... (WKT — two polygons, one on each side of the 180° antimeridian)
++-----------------------------------------------------------------------------------------------------+
+|normalized                                                                                           |
++-----------------------------------------------------------------------------------------------------+
+|MULTIPOLYGON(((180 -10,170 -10,170 10,180 10,180 -10)),((-180 10,-170 10,-170 -10,-180 -10,-180 10)))|
++-----------------------------------------------------------------------------------------------------+
 """
 
 


### PR DESCRIPTION
Two documentation fixes.

## 1. Antimeridian example failed on real clusters

The antimeridian-normalization SQL on the [Antimeridian page](https://databrickslabs.github.io/geobrix/docs/api/antimeridian) did not run on Databricks Runtime 17.3+:

- `(ST_Dump(...)).geom` row-explode — on a real cluster `ST_Dump` returns an `ARRAY<GEOMETRY>` to index positionally, not a row with a `.geom` field
- aggregate `ST_Union` over exploded rows — the working form is the two-arg scalar `ST_Union(geom_0, geom_1)`
- `ST_GeomFromWKB(...)` with no SRID — `ST_Union` requires both inputs in the same CRS

Replaced the example (in the doc-test source of truth, which the page imports via raw-loader) with the verified query, aligned the expected-output ASCII table to the real `MULTIPOLYGON` result, and updated the page prose (dump-to-array + positional index, single eastern piece, SRID-matched bridge with the reason).

**Why it shipped broken:** the doc-test container is vanilla Spark 4.0.0 with no product `ST_*` functions, so the SQL string is structurally checked only, alongside a parallel pyvx/shapely integration test. The structural check requires `gbx_st_shiftlongitude` / `gbx_st_split` / `gbx_st_wrapx` / `ST_XMax` — all still present, so it stays green. (A DBR/Serverless doc-example smoke test would close the gap; noted as a follow-up, not done here.)

## 2. Serverless force-reload tip

Added a second entry to the Serverless tip on the [installation page](https://databrickslabs.github.io/geobrix/docs/installation): how to force-reload GeoBrix mid-session without disturbing dependencies — `--force-reinstall --no-deps`, then a plain install, then `dbutils.library.restartPython()` — with a note on why `--no-deps` is mandatory.

Docs-only. `docs/tests/python/api/*` is outside `gbx:lint:python` scope; the antimeridian doc-test's structural assertions were verified to still pass.

This pull request and its description were written by Isaac.